### PR TITLE
Run OpenAPI Bundler as GitHub CI task

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,15 @@
+on: [push, pull_request]
+name: Continuous Integration
+
+jobs:
+  bundle:
+    runs-on: ubuntu-latest
+    name: Bundle OpenAPI specification
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: OpenAPI CLI Bundle
+        uses: hilary/openapi-cli-bundle-action@v0.0.2
+        with:
+          base-spec: openapi.yaml
+          bundled-spec: dist/openapi-bundled.yml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,3 +13,9 @@ jobs:
         with:
           base-spec: openapi.yaml
           bundled-spec: dist/openapi-bundled.yml
+          
+      - name: Store bundled specification
+        uses: actions/upload-artifact@v2
+        with:
+          name: openapi-bundled
+          path: dist/openapi-bundled.yml


### PR DESCRIPTION
This packages the `openapi.yml` file as a bundled spec and makes it available as artifact.

In the future even linting and validation could ideally be added as CI jobs.