### PR TITLE
Logout status_code no longer has an enum

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -92,8 +92,6 @@ paths:
                         readOnly: true
                       status_code:
                         type: number
-                        enum:
-                          - 200
                         default: 200
                         readOnly: true
                 required:


### PR DESCRIPTION
Some languages (including Dart) can only generate enum values from strings