### PR TITLE
Remove redundant wrappers around Date and DateTime

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -148,7 +148,7 @@ paths:
               schema:
                 type: string
                 example: 'twoFactorAuth=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx; Expires=Tue, 01 Jan 2030 00:00:00 GMT; Path=/; HttpOnly'
-              description: Provides a `twoFactorAuth` cookie, which can be used to bypasses the 2FA requirement for future logins on the same device.
+              description: 'Provides a `twoFactorAuth` cookie, which can be used to bypasses the 2FA requirement for future logins on the same device.'
         '401':
           $ref: '#/components/responses/MissingCredentials'
       requestBody:
@@ -190,7 +190,7 @@ paths:
               schema:
                 type: string
                 example: 'twoFactorAuth=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx; Expires=Tue, 01 Jan 2030 00:00:00 GMT; Path=/; HttpOnly'
-              description: Provides a `twoFactorAuth` cookie, which can be used to bypasses the 2FA requirement for future logins on the same device.
+              description: 'Provides a `twoFactorAuth` cookie, which can be used to bypasses the 2FA requirement for future logins on the same device.'
         '401':
           $ref: '#/components/responses/MissingCredentials'
       requestBody:
@@ -348,7 +348,8 @@ paths:
                 email:
                   type: string
                 birthday:
-                  $ref: ./openapi/components/schemas/Date.yaml
+                  type: string
+                  format: date
                 acceptedTOSVersion:
                   type: number
                 tags:
@@ -479,7 +480,8 @@ paths:
           content:
             text/plain:
               schema:
-                $ref: ./openapi/components/schemas/DateTime.yaml
+                type: string
+                format: date-time
       operationId: getSystemTime
       description: |-
         Returns in plain format the current time of the API server.

--- a/openapi/components/schemas/CurrentUser.yaml
+++ b/openapi/components/schemas/CurrentUser.yaml
@@ -62,7 +62,8 @@ properties:
   currentAvatarAssetUrl:
     type: string
   accountDeletionDate:
-    $ref: ./Date.yaml
+    type: string
+    format: date
   acceptedTOSVersion:
     type: number
   steamId:
@@ -86,7 +87,8 @@ properties:
   developerType:
     $ref: ./DeveloperType.yaml
   last_login:
-    $ref: ./DateTime.yaml
+    type: string
+    format: date-time
   last_platform:
     type: string
   allowAvatarCopying:
@@ -94,9 +96,12 @@ properties:
   status:
     $ref: ./UserStatus.yaml
   date_joined:
-    $ref: ./Date.yaml
+    type: string
+    format: date
+    readOnly: true
   isFriend:
     type: boolean
+    default: false
   friendKey:
     type: string
   onlineFriends:
@@ -137,8 +142,8 @@ required:
   - fallbackAvatar
   - currentAvatar
   - currentAvatarAssetUrl
-  # Note: This is technically required, but does not generate as nullable if marked as required
-  # - accountDeletionDate
+# Note: This is technically required, but does not generate as nullable if marked as required
+# - accountDeletionDate
   - acceptedTOSVersion
   - steamId
   - steamDetails

--- a/openapi/components/schemas/Date.yaml
+++ b/openapi/components/schemas/Date.yaml
@@ -1,8 +1,0 @@
-title: Date
-type: string
-pattern: '([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))'
-minLength: 10
-maxLength: 10
-example: '1970-01-01'
-format: date
-readOnly: true

--- a/openapi/components/schemas/DateTime.yaml
+++ b/openapi/components/schemas/DateTime.yaml
@@ -1,6 +1,0 @@
-title: DateTime
-type: string
-pattern: '[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T(2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9]\.[0-9]{3}Z'
-example: '1970-01-01T00:00:00.000Z'
-format: date-time
-readOnly: true

--- a/openapi/components/schemas/FileVersion.yaml
+++ b/openapi/components/schemas/FileVersion.yaml
@@ -11,7 +11,9 @@ properties:
   status:
     $ref: ./FileStatus.yaml
   created_at:
-    $ref: ./DateTime.yaml
+    type: string
+    format: date-time
+    readOnly: true
   file:
     $ref: ./FileData.yaml
   delta:

--- a/openapi/components/schemas/Notification.yaml
+++ b/openapi/components/schemas/Notification.yaml
@@ -25,7 +25,9 @@ properties:
     type: boolean
     default: false
   created_at:
-    $ref: ./DateTime.yaml
+    type: string
+    format: date-time
+    readOnly: true
 required:
   - id
   - senderUserId

--- a/openapi/components/schemas/User.yaml
+++ b/openapi/components/schemas/User.yaml
@@ -34,7 +34,8 @@ properties:
   developerType:
     $ref: ./DeveloperType.yaml
   last_login:
-    $ref: ./DateTime.yaml
+    type: string
+    format: date-time
   last_platform:
     type: string
   allowAvatarCopying:
@@ -42,7 +43,9 @@ properties:
   status:
     $ref: ./UserStatus.yaml
   date_joined:
-    $ref: ./Date.yaml
+    type: string
+    format: date
+    readOnly: true
   isFriend:
     type: boolean
   friendKey:


### PR DESCRIPTION
There is no point in having a DateTime model simply wrapping around a string with format `date-time`. The Model contained requirements for how the timestamp should look like, but that is already hard-defined by the OpenAPI specification:

* `date` – full-date notation as defined by [RFC 3339](https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14), section 5.6, for example, 2017-07-21
* `date-time` – the date-time notation as defined by [RFC 3339](https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14), section 5.6, for example, 2017-07-21T17:32:28Z


CC @Rexios80 This has a slight chance of affecting your code generation, but ideally it shouldn't.