### PR TITLE
Clarify Tag prefixes further

### DIFF
--- a/openapi/components/schemas/Tag.yaml
+++ b/openapi/components/schemas/Tag.yaml
@@ -3,5 +3,5 @@ title: Tag
 description: |-
   Tags are a way to grant various access, assign restrictions or other kinds of metadata to various to objects such as worlds, users and avatars.
 
-  System tags starting with `system_` are granted automatically by the system, while admin tags with `admin_` are granted manually. More prefixes such as `language_ ` exists as well.
+  System tags starting with `system_` are granted automatically by the system, while admin tags with `admin_` are granted manually. More prefixes such as `language_ ` (to indicate that a player can speak the tagged language), and `author_tag_` (provided by a world author for search and sorting) exist as well.
 minLength: 1


### PR DESCRIPTION
`language_`-prefixed tags are used for indicating spoken languages (see: vrchat.com website), additionally, I've added the `author_tag_` prefix, which is used on tags provided by the world author themselves.