### PR TITLE
feature(playermoderation): add playermoderation api

### DIFF
--- a/.github/redocly-plugins/remove-internal.js
+++ b/.github/redocly-plugins/remove-internal.js
@@ -30,7 +30,10 @@ const decorators = {
                     leave(parameter, ctx) {
                         // delete if the parameter itself is marked with x-internal
                         if (parameter['x-internal']) {
-                            delete ctx.parent[ctx.key];
+                            const pos = ctx.parent.findIndex(el => el.name === parameter.name);
+                            if (pos >= 0) {
+                                ctx.parent.splice(pos, 1);
+                            }
                         }
                     }
                 },

--- a/openapi/components/responses/OkSuccess.yaml
+++ b/openapi/components/responses/OkSuccess.yaml
@@ -1,0 +1,11 @@
+description: Success response after e.g. clearing all player moderations.
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/Error.yaml
+    examples:
+      200 OK:
+        value:
+          success:
+            message: "OK"
+            status_code: 200

--- a/openapi/components/responses/PlayerModerationDeleteOthersError.yaml
+++ b/openapi/components/responses/PlayerModerationDeleteOthersError.yaml
@@ -1,0 +1,11 @@
+description: Error response when trying to delete someone else's player moderation.
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/Error.yaml
+    examples:
+      403 Can't delete Player Moderation You Didn't Create:
+        value:
+          error:
+            message: "You definitely can't delete a playerModeration you didn't create"
+            status_code: 403

--- a/openapi/components/responses/PlayerModerationNotFoundError.yaml
+++ b/openapi/components/responses/PlayerModerationNotFoundError.yaml
@@ -1,0 +1,11 @@
+description: Error response when trying to show information about a non-existent player moderation.
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/Error.yaml
+    examples:
+      404 Player Moderation Not Found:
+        value:
+          error:
+            message: "Can't find playerModerationǃ"
+            status_code: 404

--- a/openapi/components/responses/PlayerModerationRemovedSuccess.yaml
+++ b/openapi/components/responses/PlayerModerationRemovedSuccess.yaml
@@ -1,0 +1,11 @@
+description: Success response after removing a PlayerModeration by ID.
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/Error.yaml
+    examples:
+      200 Player Moderation Removed:
+        value:
+          success:
+            message: "PlayerModeration pmod_25551a8d-6f5d-430a-88d3-9c0ce08b5244 removed"
+            status_code: 200

--- a/openapi/components/responses/PlayerModerationUnmoderatedSuccess.yaml
+++ b/openapi/components/responses/PlayerModerationUnmoderatedSuccess.yaml
@@ -1,0 +1,16 @@
+description: Success response after unmoderating a player moderation.
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/Error.yaml
+    examples:
+      200 Specific User Unmoderated:
+        value:
+          success:
+            message: "User usr_c1644b5b-3ca4-45b4-97c6-a2a0de70d469 unmoderated"
+            status_code: 200
+      200 All Of PlayerModerationType Unmoderated:
+        value:
+          success:
+            message: "PlayerModerations of type undefined removed"
+            status_code: 200

--- a/openapi/components/schemas/PlayerModeration.yaml
+++ b/openapi/components/schemas/PlayerModeration.yaml
@@ -1,4 +1,3 @@
-description: ''
 type: object
 title: PlayerModeration
 properties:

--- a/openapi/components/schemas/PlayerModeration.yaml
+++ b/openapi/components/schemas/PlayerModeration.yaml
@@ -1,0 +1,29 @@
+description: ''
+type: object
+title: PlayerModeration
+properties:
+  id:
+    $ref: ./PlayerModerationID.yaml
+  type:
+    $ref: ./PlayerModerationType.yaml
+  sourceUserId:
+    $ref: ./UserID.yaml
+  sourceDisplayName:
+    type: string
+    minLength: 1
+  targetUserId:
+    $ref: ./UserID.yaml
+  targetDisplayName:
+    type: string
+    minLength: 1
+  created:
+    type: string
+    format: date-time
+required:
+  - id
+  - type
+  - sourceUserId
+  - sourceDisplayName
+  - targetUserId
+  - targetDisplayName
+  - created

--- a/openapi/components/schemas/PlayerModerationID.yaml
+++ b/openapi/components/schemas/PlayerModerationID.yaml
@@ -1,0 +1,4 @@
+type: string
+title: PlayerModerationID
+pattern: 'pmod_[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}'
+example: pmod_25551a8d-6f5d-430a-88d3-9c0ce08b5244

--- a/openapi/components/schemas/PlayerModerationType.yaml
+++ b/openapi/components/schemas/PlayerModerationType.yaml
@@ -1,0 +1,11 @@
+type: string
+title: PlayerModerationType
+enum:
+  - mute
+  - unmute
+  - block
+  - unblock
+  - hideAvatar
+  - showAvatar
+default: showAvatar
+example: showAvatar

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1803,6 +1803,150 @@ paths:
         - apiKeyCookie: []
           authCookie: []
       description: Switches into that avatar.
+  /auth/user/playermoderations:
+    get:
+      summary: Search Player Moderations
+      tags:
+        - playermoderations
+      responses:
+        '200':
+          $ref: '#/components/responses/PlayerModerationList'
+        '401':
+          $ref: '#/components/responses/MissingCredentials'
+      operationId: getPlayerModerations
+      security:
+        - apiKeyCookie: []
+          authCookie: []
+      parameters:
+        - schema:
+            type: string
+          in: query
+          name: type
+          description: 'Must be one of PlayerModerationType, except unblock. Unblocking simply removes a block.'
+        - schema:
+            type: string
+          in: query
+          name: sourceUserId
+          description: Must be valid UserID. Trying to view someone else's moderations results with "Can't view someone else's player moderations" error.
+          x-internal: true
+        - schema:
+            type: string
+          in: query
+          name: targetUserId
+          description: Must be valid UserID.
+      description: |-
+        Returns a list of all player moderations made by **you**.
+
+        This endpoint does not have pagination, and will return *all* results. Use query parameters to limit your query if needed.
+    post:
+      summary: Moderate User
+      operationId: moderateUser
+      security:
+        - apiKeyCookie: []
+          authCookie: []
+      responses:
+        '200':
+          $ref: '#/components/responses/PlayerModeration'
+        '401':
+          $ref: '#/components/responses/MissingCredentials'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                moderated:
+                  $ref: ./components/schemas/UserID.yaml
+                type:
+                  $ref: ./components/schemas/PlayerModerationType.yaml
+              required:
+                - moderated
+                - type
+        description: ''
+      description: 'Moderate a user, e.g. unmute them or show their avatar.'
+      tags:
+        - playermoderations
+    delete:
+      summary: Clear All Player Moderations
+      operationId: clearAllPlayerModerations
+      security:
+        - apiKeyCookie: []
+          authCookie: []
+      responses:
+        '200':
+          $ref: ./components/responses/OkSuccess.yaml
+        '401':
+          $ref: '#/components/responses/MissingCredentials'
+      description: ⚠️ **This will delete every single player moderation you've ever made.**
+      tags:
+        - playermoderations
+  /auth/user/unplayermoderate:
+    put:
+      summary: Unmoderate User
+      operationId: unmoderateUser
+      security:
+        - apiKeyCookie: []
+          authCookie: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                moderated:
+                  $ref: ./components/schemas/UserID.yaml
+                type:
+                  $ref: ./components/schemas/PlayerModerationType.yaml
+              required:
+                - type
+      description: 'Removes a player moderation previously added through `moderateUser`. E.g if you previuosly have shown their avatar, but now want to reset it to default.'
+      responses:
+        '200':
+          $ref: ./components/responses/PlayerModerationUnmoderatedSuccess.yaml
+        '401':
+          $ref: '#/components/responses/MissingCredentials'
+      tags:
+        - playermoderations
+  '/auth/user/playermoderations/{playerModerationId}':
+    get:
+      summary: Get Player Moderation
+      tags:
+        - playermoderations
+      responses:
+        '200':
+          $ref: '#/components/responses/PlayerModeration'
+        '401':
+          $ref: '#/components/responses/MissingCredentials'
+        '404':
+          $ref: ./components/responses/PlayerModerationNotFoundError.yaml
+      operationId: getPlayerModeration
+      security:
+        - apiKeyCookie: []
+          authCookie: []
+      description: Returns a single Player Moderation. This returns the exact same amount of information as the more generalised `getPlayerModerations`.
+    delete:
+      summary: Delete Player Moderation
+      operationId: deletePlayerModeration
+      security:
+        - apiKeyCookie: []
+          authCookie: []
+      responses:
+        '200':
+          $ref: ./components/responses/PlayerModerationRemovedSuccess.yaml
+        '401':
+          $ref: '#/components/responses/MissingCredentials'
+        '403':
+          $ref: ./components/responses/PlayerModerationDeleteOthersError.yaml
+      description: Deletes a specific player moderation based on it's `pmod_` ID. The website uses `unmoderateUser` instead. You can delete the same player moderation multiple times successfully.
+      tags:
+        - playermoderations
+    parameters:
+      - schema:
+          type: string
+        name: playerModerationId
+        in: path
+        required: true
 components:
   schemas: {}
   securitySchemes:
@@ -2281,6 +2425,20 @@ components:
         application/json:
           schema:
             $ref: ./components/schemas/CurrentUser.yaml
+    PlayerModerationList:
+      description: Returns a list of PlayerModeration objects.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: ./components/schemas/PlayerModeration.yaml
+    PlayerModeration:
+      description: Returns a single PlayerModeration object.
+      content:
+        application/json:
+          schema:
+            $ref: ./components/schemas/PlayerModeration.yaml
   examples: {}
   parameters:
     number:
@@ -2507,6 +2665,7 @@ tags:
   - name: files
   - name: friends
   - name: notifications
+  - name: playermoderations
   - name: system
   - name: users
   - name: worlds

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1807,7 +1807,7 @@ paths:
     get:
       summary: Search Player Moderations
       tags:
-        - playermoderations
+        - playermoderation
       responses:
         '200':
           $ref: '#/components/responses/PlayerModerationList'
@@ -1866,7 +1866,7 @@ paths:
         description: ''
       description: 'Moderate a user, e.g. unmute them or show their avatar.'
       tags:
-        - playermoderations
+        - playermoderation
     delete:
       summary: Clear All Player Moderations
       operationId: clearAllPlayerModerations
@@ -1880,7 +1880,7 @@ paths:
           $ref: '#/components/responses/MissingCredentials'
       description: ⚠️ **This will delete every single player moderation you've ever made.**
       tags:
-        - playermoderations
+        - playermoderation
   /auth/user/unplayermoderate:
     put:
       summary: Unmoderate User
@@ -1907,12 +1907,12 @@ paths:
         '401':
           $ref: '#/components/responses/MissingCredentials'
       tags:
-        - playermoderations
+        - playermoderation
   '/auth/user/playermoderations/{playerModerationId}':
     get:
       summary: Get Player Moderation
       tags:
-        - playermoderations
+        - playermoderation
       responses:
         '200':
           $ref: '#/components/responses/PlayerModeration'
@@ -1940,7 +1940,7 @@ paths:
           $ref: ./components/responses/PlayerModerationDeleteOthersError.yaml
       description: Deletes a specific player moderation based on it's `pmod_` ID. The website uses `unmoderateUser` instead. You can delete the same player moderation multiple times successfully.
       tags:
-        - playermoderations
+        - playermoderation
     parameters:
       - schema:
           type: string
@@ -2665,7 +2665,7 @@ tags:
   - name: files
   - name: friends
   - name: notifications
-  - name: playermoderations
+  - name: playermoderation
   - name: system
   - name: users
   - name: worlds


### PR DESCRIPTION
Fixes #9 

Lots of information on the Markdown version of the docs were incorrect/outdated. Endpoints such as `/blocks` and `/unblocks` doesn't exist (anymore).

It also mixed together Moderation (admin) and PlayerModeration (player). Moderation is when you perma-ban or kick someone from the game. PlayerModeration is when you (un)mute, (un)block or show/hide their avatar, and what this PR focuses on documenting.

Calling moderation endpoints should be carefully threaded, as it is suspected muted or blocking someone, especially when many people does it, generates negative scoring in their internal moderation system.

---

**Trivia:** Every person you friend is also added as "unmute" automatically, which is a way to see **when** you friended them. (unless you've accidentally wiped all your playermoderations).

---

This PR would also conclude the "Docsify<>OpenAPI Parity" project, meaning the OpenAPI specification should by then contain at least all the information contained in the current Docsify documentation. 🎉