### PR TITLE
fix(favorite): type is not read-only, it is submitted during addFavorite

### DIFF
--- a/openapi/components/schemas/FavoriteType.yaml
+++ b/openapi/components/schemas/FavoriteType.yaml
@@ -4,4 +4,3 @@ enum:
   - world
   - friend
   - avatar
-readOnly: true


### PR DESCRIPTION
Setting `type` as read-only caused it to not show up as as part of the request body for `addFavorite`. Thanks for Devin_Lucashu for helping in finding this.