### PR TITLE
fix!: deprecate `/health`

### DIFF
--- a/openapi/components/paths/system.yaml
+++ b/openapi/components/paths/system.yaml
@@ -10,11 +10,15 @@ paths:
       tags:
         - system
       operationId: getHealth
-      description: 'Gets the overall health status, the server name, and the current build version tag of the API.'
+      description: |-
+        ~~Gets the overall health status, the server name, and the current build version tag of the API.~~
+
+        **DEPRECATED:** VRChat has suddenly restricted this endpoint for unknown reasons, and now always return 401 Unauthorized.
       security: []
       responses:
         '200':
           $ref: ../responses/system/APIHealthResponse.yaml
+      deprecated: true
   /config:
     get:
       summary: Fetch API Config


### PR DESCRIPTION
`/api/1/health` now always return:
```json
{
  "error":{
    "status_code":401
  }
}
```