### PR TITLE
Made instance ownerId not required

### DIFF
--- a/openapi/components/schemas/Instance.yaml
+++ b/openapi/components/schemas/Instance.yaml
@@ -88,7 +88,6 @@ required:
   - location
   - n_users
   - name
-  - ownerId
   - permanent
   - photonRegion
   - platforms


### PR DESCRIPTION
VRChat creates public instances of popular worlds that have no owner