### PR TITLE
fix: add missing 'queued' as enum for FileStatus

### DIFF
--- a/openapi/components/schemas/FileStatus.yaml
+++ b/openapi/components/schemas/FileStatus.yaml
@@ -3,6 +3,7 @@ enum:
   - waiting
   - complete
   - none
+  - queued
 example: complete
 title: FileStatus
 default: waiting


### PR DESCRIPTION
Fixes - Invalid value for `value` (queued), must be one of ['waiting', 'complete', 'none'] after creating 2nd file version.