### PR TITLE
Fix unitypackage integer format.

### DIFF
--- a/openapi/components/schemas/UnityPackage.yaml
+++ b/openapi/components/schemas/UnityPackage.yaml
@@ -33,6 +33,7 @@ properties:
   unitySortNumber:
     minimum: 0
     type: integer
+    format: int64
   unityVersion:
     default: 5.3.4p1
     example: 2018.4.12f1


### PR DESCRIPTION
By default type integer uses int32 and because of parsers that needs to be int64
``JSON integer 20180420000 is too large or small for an Int32. Path 'world.unityPackages[0].unitySortNumber', line 1, position 2676.``