### PR TITLE
Removed API arguments

### DIFF
--- a/openapi/components/schemas/World.yaml
+++ b/openapi/components/schemas/World.yaml
@@ -116,7 +116,6 @@ properties:
     type: integer
 required:
   - assetUrl
-  - assetUrlObject
   - authorId
   - authorName
   - capacity
@@ -130,13 +129,11 @@ required:
   - name
   - namespace
   - organization
-  - pluginUrlObject
   - popularity
   - publicationDate
   - releaseStatus
   - tags
   - thumbnailImageUrl
-  - unityPackageUrlObject
   - unityPackages
   - updated_at
   - version

--- a/openapi/components/schemas/World.yaml
+++ b/openapi/components/schemas/World.yaml
@@ -5,8 +5,6 @@ properties:
   assetUrl:
     type: string
     description: Empty if unauthenticated.
-  assetUrlObject:
-    type: object
   authorId:
     $ref: ./UserID.yaml
   authorName:
@@ -66,8 +64,6 @@ properties:
     default: vrchat
     minLength: 1
     type: string
-  pluginUrlObject:
-    type: object
   popularity:
     default: 0
     example: 8
@@ -100,8 +96,6 @@ properties:
   thumbnailImageUrl:
     minLength: 1
     type: string
-  unityPackageUrlObject:
-    type: object
   unityPackages:
     type: array
     description: Empty if unauthenticated.


### PR DESCRIPTION
Removed AssetUrlObject, PluginUrlObject and UnityPckageUrlObject from World response as VRChat no longer returns those.