### PR TITLE
Deprecates the type query parameter for the List Notifications endpoint

### DIFF
--- a/openapi/components/paths/notifications.yaml
+++ b/openapi/components/paths/notifications.yaml
@@ -27,7 +27,7 @@ paths:
             example: all
           in: query
           name: type
-          description: Only send notifications of this type (can use `all` for all).
+          description: 'Only send notifications of this type (can use `all` for all). This parameter no longer does anything, and is deprecated.'
           deprecated: true
         - schema:
             type: boolean

--- a/openapi/components/paths/notifications.yaml
+++ b/openapi/components/paths/notifications.yaml
@@ -28,6 +28,7 @@ paths:
           in: query
           name: type
           description: Only send notifications of this type (can use `all` for all).
+          deprecated: true
         - schema:
             type: boolean
           in: query


### PR DESCRIPTION
Deprecates the `type` query parameter for the `List Notifications` endpoint, as well as tweaks the description.
Let me know if I should fix anything, thanks.

Fixes #170 