### PR TITLE
Deprecate usernames

### DIFF
--- a/openapi/components/paths/users.yaml
+++ b/openapi/components/paths/users.yaml
@@ -60,6 +60,12 @@ paths:
         - apiKeyCookie: []
           authCookie: []
       description: Get public user information about a specific user using their name.
+      description: |-
+        ~~Get public user information about a specific user using their name.~~
+
+        **DEPRECATED:** VRChat API no longer return usernames of other users. [See issue by Tupper for more information](https://github.com/pypy-vrc/VRCX/issues/429).
+        This endpoint now require Admin Credentials.
+      deprecated: true
   '/users/{userId}':
     parameters:
       - $ref: ../parameters.yaml#/userId

--- a/openapi/components/responses/notifications/NotificationResponse.yaml
+++ b/openapi/components/responses/notifications/NotificationResponse.yaml
@@ -8,7 +8,6 @@ content:
         value:
           id: frq_00000000-0000-0000-0000-000000000000
           senderUserId: usr_c1644b5b-3ca4-45b4-97c6-a2a0de70d469
-          senderUsername: tupper
           type: friendRequest
           message: ''
           details: '{}'

--- a/openapi/components/responses/notifications/SendNotificationResponse.yaml
+++ b/openapi/components/responses/notifications/SendNotificationResponse.yaml
@@ -9,7 +9,6 @@ content:
           id: frq_00000000-0000-0000-0000-000000000000
           recieverUserId: usr_00000000-0000-0000-0000-000000000000
           senderUserId: usr_c1644b5b-3ca4-45b4-97c6-a2a0de70d469
-          senderUsername: tupper
           type: friendRequest
           message: ''
           details: '{}'

--- a/openapi/components/schemas/CurrentUser.yaml
+++ b/openapi/components/schemas/CurrentUser.yaml
@@ -123,9 +123,11 @@ properties:
     type: string
   username:
     type: string
+    deprecated: true
+    description: -|
+      **DEPRECATED:** VRChat API no longer return usernames of other users. [See issue by Tupper for more information](https://github.com/pypy-vrc/VRCX/issues/429).
 required:
   - id
-  - username
   - displayName
   - userIcon
   - bio

--- a/openapi/components/schemas/LimitedUser.yaml
+++ b/openapi/components/schemas/LimitedUser.yaml
@@ -33,13 +33,15 @@ properties:
     type: string
   username:
     type: string
+    deprecated: true
+    description: -|
+      **DEPRECATED:** VRChat API no longer return usernames of other users. [See issue by Tupper for more information](https://github.com/pypy-vrc/VRCX/issues/429).
   location:
     type: string
   friendKey:
     type: string
 required:
   - id
-  - username
   - displayName
   - userIcon
   - profilePicOverride

--- a/openapi/components/schemas/Notification.yaml
+++ b/openapi/components/schemas/Notification.yaml
@@ -23,12 +23,14 @@ properties:
   senderUsername:
     minLength: 1
     type: string
+    deprecated: true
+    description: -|
+      **DEPRECATED:** VRChat API no longer return usernames of other users. [See issue by Tupper for more information](https://github.com/pypy-vrc/VRCX/issues/429).
   type:
     $ref: ./NotificationType.yaml
 required:
   - id
   - senderUserId
-  - senderUsername
   - type
   - message
   - details

--- a/openapi/components/schemas/SentNotification.yaml
+++ b/openapi/components/schemas/SentNotification.yaml
@@ -22,6 +22,9 @@ properties:
   senderUsername:
     minLength: 1
     type: string
+    deprecated: true
+    description: -|
+      **DEPRECATED:** VRChat API no longer return usernames of other users. [See issue by Tupper for more information](https://github.com/pypy-vrc/VRCX/issues/429).
   type:
     $ref: ./NotificationType.yaml
 required:
@@ -31,7 +34,6 @@ required:
   - message
   - recieverUserId
   - senderUserId
-  - senderUsername
   - type
 title: SentNotification
 type: object

--- a/openapi/components/schemas/User.yaml
+++ b/openapi/components/schemas/User.yaml
@@ -70,7 +70,11 @@ properties:
     type: string
   username:
     type: string
-    description: 'A users unique name, used during login. This is different from `displayName` which is what shows up in-game. A users `username` can never be changed.'
+    description: -|
+      A users unique name, used during login. This is different from `displayName` which is what shows up in-game. A users `username` can never be changed.'
+
+      **DEPRECATED:** VRChat API no longer return usernames of other users. [See issue by Tupper for more information](https://github.com/pypy-vrc/VRCX/issues/429).
+    deprecated: true
   worldId:
     $ref: ./WorldID.yaml
 required:
@@ -95,4 +99,3 @@ required:
   - statusDescription
   - tags
   - userIcon
-  - username

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: VRChat API Documentation
-  version: 1.7.7
+  version: 2.0.0
   contact:
     name: Unofficial VRChat API Documentation Project
     url: 'https://github.com/VRChatAPI'


### PR DESCRIPTION
Fixes #183 , as reported by https://github.com/pypy-vrc/VRCX/issues/429

# Change

This PR deprecates all usage of `username` in `CurrentUser`, `LimitedUser` and `User` objects, as well as preemptively deprecating `senderUsername` in all Notification objects. It also deprecates the GET endpoint `users/{username}/name`. This change will affect both web documentation and the generated SDK's, which I suggest would justify a major bump in version number after this is merged.

# Background
As of 2022-10-25, Tupper made a post on VRCX's GitHub that usernames would no longer be returned.

Image for archival:
![image](https://user-images.githubusercontent.com/5008081/198824056-8a41048e-eeb4-40be-a36d-9266836bee0f.png)
![image](https://user-images.githubusercontent.com/5008081/198824069-afe8699b-1cb4-456d-aeac-a03770de1b95.png)

This change was implemented as of 2022-10-28:
![image](https://user-images.githubusercontent.com/5008081/198824085-27e0cfd0-9aea-4a38-ad30-2ff4fa276fe6.png)

We are extremely thankful for this heads-up notification, as it can help mitigate some peoples Discord Bot's and other software from breaking abruptly. Thanks Tupper! :heart: 