### PR TITLE
Removed friendRequestStatus from required user fields

### DIFF
--- a/openapi/components/schemas/User.yaml
+++ b/openapi/components/schemas/User.yaml
@@ -87,7 +87,6 @@ required:
   - developerType
   - displayName
   - friendKey
-  - friendRequestStatus
   - id
   - isFriend
   - last_activity


### PR DESCRIPTION
This field is not included in the user data received from the websocket