### PR TITLE
Add documentation deployment without SDK generation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
       - uses: actions/checkout@v2
       - name: 'Cache node_modules'
         uses: actions/cache@v2
@@ -50,7 +50,8 @@ jobs:
           path: dist
 
   pages:
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    # Only if main branch
+    if: github.ref == 'refs/heads/main'
     needs: bundle
     runs-on: ubuntu-latest
     name: Upload OpenAPI specification to GitHub Pages
@@ -74,11 +75,16 @@ jobs:
           branch: gh-pages
           folder: dist
 
+  version_check:
+    # Only if tag "release/*" is pushed
+    if: ${{ startsWith(github.ref, 'refs/tags/release/') }}
+    needs: pages
+
   # https://blog.marcnuri.com/triggering-github-actions-across-different-repositories
   # Make sure this is same as in sdk_generate.yaml
   sdk_generate:
-    needs: pages
     runs-on: ubuntu-latest
+    needs: version_check
     name: Trigger Remote SDK builds
     strategy:
       matrix:


### PR DESCRIPTION
This PR updates the deployment process for the specification to allow deploying the documentation to the website without triggering the generation of the SDKs. This allows us to update the documentation more quickly and independently of the SDK generation process, which can be time-consuming due to the extensive testing required.

The new workflow is that any PR going into `main` will be deployed to the website, while SDK generation will only happen once a tag with `release/x.x.x` is created. This also allows us to create other tags, such as `dev/x.x.x` or `archive/removal-of-specific-thing` for testing purposes without generating the SDKs.