### PR TITLE
Fix CI logic to allow building SDK

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
   version_check:
     # Only if tag "release/*" is pushed
     if: ${{ startsWith(github.ref, 'refs/tags/release/') }}
-    needs: pages
+    needs: bundle
     name: Check if OpenAPI specification version is matching tag
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Logic error, where it was checking if ref is **both** "main" and the tag, which can never happen.