### PR TITLE
Add accountDeletionLog to CurrentUser

### DIFF
--- a/openapi/components/schemas/AccountDeletionLog.yaml
+++ b/openapi/components/schemas/AccountDeletionLog.yaml
@@ -1,0 +1,17 @@
+title: AccountDeletionLog
+type: object
+properties:
+  message:
+    type: string
+    default: "Deletion requested"
+    example: "Deletion requested"
+    description: Typically "Deletion requested" or "Deletion canceled". Other messages like "Deletion completed" may exist, but are these are not possible to see as a regular user.
+  deletionScheduled:
+    type: string
+    format: date-time
+    nullable: true
+    description: When the deletion is scheduled to happen, standard is 14 days after the request.
+  dateTime:
+    type: string
+    format: date-time
+    description: Date and time of the deletion request.

--- a/openapi/components/schemas/CurrentUser.yaml
+++ b/openapi/components/schemas/CurrentUser.yaml
@@ -7,18 +7,25 @@ properties:
     format: date
     nullable: true
     type: string
+  accountDeletionLog:
+    description: ' '
+    type: array
+    items:
+      $ref: ./AccountDeletionLog.yaml
   activeFriends:
+    description: ' '
+    type: array
     items:
       $ref: ./UserID.yaml
-    type: array
   allowAvatarCopying:
     type: boolean
   bio:
     type: string
   bioLinks:
+    description: ' '
+    type: array  
     items:
       type: string
-    type: array
   currentAvatar:
     $ref: ./AvatarID.yaml
   currentAvatarAssetUrl:
@@ -39,11 +46,11 @@ properties:
   fallbackAvatar:
     $ref: ./AvatarID.yaml
   friendGroupNames:
+    type: array
     deprecated: true
     description: Always empty array.
     items:
       type: string
-    type: array
   friendKey:
     type: string
   friends:


### PR DESCRIPTION
VRChat has added `accountDeletionLog` field to the `CurrentUser` object. This field contains a list of AccountDeletionLog entries, which are shown below. The list itself may be `null` if the user has never requested deletion.

Example:

accountDeletionLog |  
-- | --
0 |  
message | "Deletion requested"
deletionScheduled | "2022-12-19T18:06:16.333Z"
dateTime | "2022-12-05T18:06:16.335Z"
1 |  
message | "Deletion canceled"
dateTime | "2022-12-05T18:06:31.190Z"

