### PR TITLE
DeleteUser has moved from `user` to `users`

### DIFF
--- a/openapi/components/paths.yaml
+++ b/openapi/components/paths.yaml
@@ -16,8 +16,8 @@
   $ref: "./paths/authentication.yaml#/paths/~1auth"
 "/logout":
   $ref: "./paths/authentication.yaml#/paths/~1logout"
-"/user/{userId}/delete":
-  $ref: "./paths/authentication.yaml#/paths/~1user~1{userId}~1delete"
+"/users/{userId}/delete":
+  $ref: "./paths/authentication.yaml#/paths/~1users~1{userId}~1delete"
 
 # avatars
 

--- a/openapi/components/paths/authentication.yaml
+++ b/openapi/components/paths/authentication.yaml
@@ -135,7 +135,7 @@ paths:
         - authentication
       security:
         - authCookie: []
-  '/user/{userId}/delete':
+  '/users/{userId}/delete':
     parameters:
       - $ref: ../parameters.yaml#/userId
     put:


### PR DESCRIPTION
The "Delete User" (used to mark yourself for deletion) has moved from `user` to `users`.

Another question is why this is under AuthenticationAPI, and not UsersAPI, as it is a /users endpoint, but that is out of scope of this PR.