### PR TITLE
Remove legacy mention of avatar playermoderation

### DIFF
--- a/openapi/components/paths/playermoderation.yaml
+++ b/openapi/components/paths/playermoderation.yaml
@@ -13,8 +13,8 @@ info:
 
     There are three different user-targetted permission options:
 
-    - Mode 1: interactOn/showAvatar/unmute
-    - Mode 2: interactOff/hideAvatar/mute
+    - Mode 1: interactOn/unmute/unblock
+    - Mode 2: interactOff/mute/unblock
     - *Default setting*
 
     **Example:**

--- a/openapi/components/paths/playermoderation.yaml
+++ b/openapi/components/paths/playermoderation.yaml
@@ -14,7 +14,7 @@ info:
     There are three different user-targetted permission options:
 
     - Mode 1: interactOn/unmute/unblock
-    - Mode 2: interactOff/mute/unblock
+    - Mode 2: interactOff/mute/block
     - *Default setting*
 
     **Example:**


### PR DESCRIPTION
PlayerModartions of type `showAvatar` and `hideAvatar` has already been deprecated in October, as stated further down the file. This PR only removes the examples still using these deprecated types.