### PR TITLE
Fix GitHub CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,15 +30,15 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - uses: actions/checkout@v3
       - name: 'Cache node_modules'
         uses: actions/cache@v3
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-v14-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-v16-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-v14
+            ${{ runner.os }}-node-v16
 
       - name: Bundle OpenAPI Specification 📦
         run: npm run bundle


### PR DESCRIPTION
The step before installs all dependencies as v16. When the next step then tries to fetch v14, they don't exist. This worked for a few weeks after the change that broke it, because the old cache persisted. But now the v14 cache is gone, which is why it suddenly broke.