### PR TITLE
Change response in /groups/join/ endpoint to return GroupMember

### DIFF
--- a/openapi/components/paths/groups.yaml
+++ b/openapi/components/paths/groups.yaml
@@ -459,7 +459,7 @@ paths:
       - $ref: ../parameters.yaml#/groupId
     post:
       summary: Join Group
-      description: Join a Group by ID and returns the joined Group.
+      description: Join a Group by ID and returns the member object.
       operationId: joinGroup
       tags:
         - groups

--- a/openapi/components/paths/groups.yaml
+++ b/openapi/components/paths/groups.yaml
@@ -465,7 +465,7 @@ paths:
         - groups
       responses:
         '200':
-          $ref: ../responses/groups/GroupResponse.yaml
+          $ref: ../responses/groups/GroupMemberResponse.yaml
         '400':
           $ref: ../responses/groups/GroupAlreadyMemberError.yaml
         '401':


### PR DESCRIPTION
groups/joins returns the Newly created Group Member, not the just joined Group.