### PR TITLE
fix: APIConfigDownloadURLList now includes vcc and bootstrap

### DIFF
--- a/openapi/components/schemas/APIConfig.yaml
+++ b/openapi/components/schemas/APIConfig.yaml
@@ -59,6 +59,8 @@ example:
     sdk2: 'https://files.vrchat.cloud/sdk/VRCSDK2-2021.09.03.09.25_Public.unitypackage'
     sdk3-avatars: 'https://files.vrchat.cloud/sdk/VRCSDK3-AVATAR-2021.09.03.09.25_Public.unitypackage'
     sdk3-worlds: 'https://files.vrchat.cloud/sdk/VRCSDK3-WORLD-2021.09.03.09.25_Public.unitypackage'
+    vcc: 'https://vrcpm.vrchat.cloud/vcc/Builds/2.1.1/VRChat_CreatorCompanion_Setup_2.1.1.exe'
+    bootstrap: 'https://github.com/vrchat/packages/releases/download/resolvers/latest-resolver.unitypackage'
   dynamicWorldRows:
     - index: 1
       name: Hot

--- a/openapi/components/schemas/APIConfigDownloadURLList.yaml
+++ b/openapi/components/schemas/APIConfigDownloadURLList.yaml
@@ -6,6 +6,8 @@ required:
   - sdk2
   - sdk3-avatars
   - sdk3-worlds
+  - vcc
+  - bootstrap
 properties:
   sdk2:
     deprecated: true
@@ -18,5 +20,13 @@ properties:
     type: string
   sdk3-worlds:
     description: Download link for SDK3 for Worlds
+    minLength: 1
+    type: string
+  vcc:
+    description: Download link for the Creator Companion
+    minLength: 1
+    type: string
+  bootstrap:
+    description: Download link for ???
     minLength: 1
     type: string


### PR DESCRIPTION
```json
{
  ...
  "downloadUrls": {
    "sdk2": "https://assets.vrchat.com/sdk/VRCSDK2-2022.04.20.16.27_Public.unitypackage",
    "sdk3-worlds": "https://assets.vrchat.com/sdk/VRChat-Worlds-SDK-3.2.0.unitypackage",
    "sdk3-avatars": "https://assets.vrchat.com/sdk/VRChat-Avatars-SDK-3.2.0.unitypackage",
    "vcc": "https://vrcpm.vrchat.cloud/vcc/Builds/2.1.1/VRChat_CreatorCompanion_Setup_2.1.1.exe",
    "bootstrap": "https://github.com/vrchat/packages/releases/download/resolvers/latest-resolver.unitypackage"
  },
}