### PR TITLE
Add 'message' notification type to enum

### DIFF
--- a/openapi/components/schemas/CurrentUserPresence.yaml
+++ b/openapi/components/schemas/CurrentUserPresence.yaml
@@ -32,13 +32,8 @@ properties:
     nullable: true
   status:
     type: string
-<<<<<<< HEAD
     description: either a UserStatus or empty string
     nullable: true
-=======
-    nullable: true
-    description: either a UserStatus or empty string
->>>>>>> 188f03f (Change CurrentUserPresence instanceType and status properties to nullable string)
   travelingToInstance:
     type: string
     nullable: true

--- a/openapi/components/schemas/CurrentUserPresence.yaml
+++ b/openapi/components/schemas/CurrentUserPresence.yaml
@@ -32,8 +32,13 @@ properties:
     nullable: true
   status:
     type: string
+<<<<<<< HEAD
     description: either a UserStatus or empty string
     nullable: true
+=======
+    nullable: true
+    description: either a UserStatus or empty string
+>>>>>>> 188f03f (Change CurrentUserPresence instanceType and status properties to nullable string)
   travelingToInstance:
     type: string
     nullable: true

--- a/openapi/components/schemas/NotificationType.yaml
+++ b/openapi/components/schemas/NotificationType.yaml
@@ -3,6 +3,7 @@ enum:
   - friendRequest
   - invite
   - inviteResponse
+  - message
   - requestInvite
   - requestInviteResponse
   - votetokick


### PR DESCRIPTION
This notification type appears to be used for system messages, e.g., VRC+ gift notifications. The type-specific payload seems to be rather arbitrary, so I will be looking into that more.