### PR TITLE
LimitedUser image fields shouldn't be required

### DIFF
--- a/openapi/components/schemas/LimitedUser.yaml
+++ b/openapi/components/schemas/LimitedUser.yaml
@@ -43,11 +43,7 @@ properties:
 required:
   - id
   - displayName
-  - userIcon
-  - profilePicOverride
   - statusDescription
-  - currentAvatarImageUrl
-  - currentAvatarThumbnailImageUrl
   - developerType
   - last_platform
   - status


### PR DESCRIPTION
Closes https://github.com/vrchatapi/specification/issues/273

Unfortunately I don't have sample json with these missing, but we do have Firebase Crashlytics logs of this happening with real users