### PR TITLE
fix: fix lastPostReadAt nullability for GroupMember

### DIFF
--- a/openapi/components/schemas/GroupLimitedMember.yaml
+++ b/openapi/components/schemas/GroupLimitedMember.yaml
@@ -49,5 +49,6 @@ properties:
   lastPostReadAt:
     type: string
     format: date-time
+    nullable: true
   hasJoinedFromPurchase:
     type: boolean

--- a/openapi/components/schemas/GroupMember.yaml
+++ b/openapi/components/schemas/GroupMember.yaml
@@ -52,5 +52,6 @@ properties:
   lastPostReadAt:
     type: string
     format: date-time
+    nullable: true
   hasJoinedFromPurchase:
     type: boolean


### PR DESCRIPTION
The lastPostReadAt field for group members can be null through inspection of the api responses.