### PR TITLE
fix(group): specify joinedAt as nullable

### DIFF
--- a/openapi/components/schemas/GroupMember.yaml
+++ b/openapi/components/schemas/GroupMember.yaml
@@ -26,6 +26,7 @@ properties:
   joinedAt:
     type: string
     format: date-time
+    nullable: true
   membershipStatus:
     type: string
     example: member


### PR DESCRIPTION
Specify that GroupMember joinedAt can be nullable since it is null for the GroupMembers returned from `/groups/{groupId}/bans`