### PR TITLE
refactor(group): add an enum for GroupJoinRequestAction

### DIFF
--- a/openapi/components/requests/RespondGroupJoinRequest.yaml
+++ b/openapi/components/requests/RespondGroupJoinRequest.yaml
@@ -2,4 +2,6 @@ title: RespondGroupJoinRequest
 type: object
 properties:
   action:
-    type: string
+    $ref: ../schemas/GroupJoinRequestAction.yaml
+required:
+  - action

--- a/openapi/components/schemas/GroupJoinRequestAction.yaml
+++ b/openapi/components/schemas/GroupJoinRequestAction.yaml
@@ -1,0 +1,6 @@
+example: accept
+title: GroupJoinRequestAction
+type: string
+enum:
+  - accept
+  - reject


### PR DESCRIPTION
Add an enum for GroupJoinRequestAction instead of having it be an unconstrained string.