### PR TITLE
fix(group): add "banned" to GroupMembershipStatus

### DIFF
--- a/openapi/components/schemas/GroupMemberStatus.yaml
+++ b/openapi/components/schemas/GroupMemberStatus.yaml
@@ -4,5 +4,6 @@ enum:
   - member
   - requested
   - invited
+  - banned
 default: inactive
 example: member


### PR DESCRIPTION
Add "banned" to GroupMembershipStatus. This shows up on `/groups/{groupId}/bans`.