### PR TITLE
fix(group): specify that currentAvatarThumbnailImageUrl is nullable

### DIFF
--- a/openapi/components/schemas/GroupMemberLimitedUser.yaml
+++ b/openapi/components/schemas/GroupMemberLimitedUser.yaml
@@ -14,6 +14,7 @@ properties:
     type: string
   currentAvatarThumbnailImageUrl:
     type: string
+    nullable: true
   currentAvatarTags:
     type: array
     items:


### PR DESCRIPTION
Specify that currentAvatarThumbnailImageUrl on a GroupMemberLimitedUser is nullable.