### PR TITLE
fix(instance): specify that ownerId can be groupId or null

### DIFF
--- a/openapi/components/schemas/Instance.yaml
+++ b/openapi/components/schemas/Instance.yaml
@@ -42,7 +42,7 @@ properties:
     minLength: 1
     example: '12345'
   ownerId:
-    $ref: ./UserID.yaml
+    $ref: ./InstanceOwnerId.yaml
   permanent:
     default: false
     type: boolean

--- a/openapi/components/schemas/InstanceOwnerId.yaml
+++ b/openapi/components/schemas/InstanceOwnerId.yaml
@@ -1,0 +1,5 @@
+example: usr_c1644b5b-3ca4-45b4-97c6-a2a0de70d469
+title: InstanceOwnerId
+type: string
+description: A groupId if the instance type is "group", null if instance type is public, or a userId otherwise
+nullable: true


### PR DESCRIPTION
Specify that an instance's ownerId can be a groupId or null depending on the instance type.