### PR TITLE
fix(instance): make roleRestricted not required

### DIFF
--- a/openapi/components/schemas/Instance.yaml
+++ b/openapi/components/schemas/Instance.yaml
@@ -126,7 +126,6 @@ required:
   - queueEnabled
   - queueSize
   - recommendedCapacity
-  - roleRestricted
   - strict
   - userCount
   - world


### PR DESCRIPTION
Make roleRestricted not a required property since it isn't always returned depending on the instance type.