### PR TITLE
fix(groups): specify that GroupMemberLimitedUser's thumbnailUrl can be null

### DIFF
--- a/openapi/components/schemas/GroupMemberLimitedUser.yaml
+++ b/openapi/components/schemas/GroupMemberLimitedUser.yaml
@@ -8,6 +8,7 @@ properties:
     type: string
   thumbnailUrl:
     type: string
+    nullable: true
   iconUrl:
     type: string
   profilePicOverride:


### PR DESCRIPTION
Specify that a GroupMemberLimitedUsers's thumbnailUrl can be null as seen in multiple real vrchat responses.