### PR TITLE
Added support for group posts controls

### DIFF
--- a/openapi/components/paths.yaml
+++ b/openapi/components/paths.yaml
@@ -134,6 +134,10 @@
   $ref: "./paths/groups.yaml#/paths/~1groups~1{groupId}~1members~1{userId}~1roles~1{groupRoleId}"
 "/groups/{groupId}/permissions":
   $ref: "./paths/groups.yaml#/paths/~1groups~1{groupId}~1permissions"
+"/groups/{groupId}/posts":
+  $ref: "./paths/groups.yaml#/paths/~1groups~1{groupId}~1posts"
+"/groups/{groupId}/posts/{notificationId}":
+  $ref: "./paths/groups.yaml#/paths/~1groups~1{groupId}~1posts~1{notificationId}"
 "/groups/{groupId}/requests":
   $ref: "./paths/groups.yaml#/paths/~1groups~1{groupId}~1requests"
 "/groups/{groupId}/requests/{userId}":

--- a/openapi/components/paths/groups.yaml
+++ b/openapi/components/paths/groups.yaml
@@ -641,6 +641,68 @@ paths:
           $ref: ../responses/groups/GroupNotFoundError.yaml
       security:
         - authCookie: []
+  '/groups/{groupId}/posts':
+    parameters:
+      - $ref: ../parameters.yaml#/groupId
+    get:
+      summary: Get posts from a Group
+      description: Get posts from a Group
+      operationId: getGroupPost
+      tags:
+        - groups
+      parameters:
+        - $ref: ../parameters.yaml#/number
+        - $ref: ../parameters.yaml#/offset
+        - schema:
+            type: boolean
+          in: query
+          name: publicOnly
+          description: See public posts only.
+      responses:
+        '200':
+          $ref: ../responses/groups/GroupPostResponse.yaml
+        '401':
+          $ref: ../responses/MissingCredentialsError.yaml
+      security:
+        - authCookie: []
+    post:
+      summary: Create a post in a Group
+      description: Create a post in a Group.
+      operationId: addGroupPost
+      tags:
+        - groups
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../requests/CreateGroupPostRequest.yaml
+      responses:
+        '200':
+          $ref: ../responses/groups/GroupPostResponse.yaml
+        '401':
+          $ref: ../responses/MissingCredentialsError.yaml
+      security:
+        - authCookie: []
+  '/groups/{groupId}/posts/{notificationId}':
+    parameters:
+      - $ref: ../parameters.yaml#/groupId
+      - $ref: ../parameters.yaml#/notificationId
+    delete:
+      summary: Delete a Group post
+      description: Delete a Group post
+      operationId: deleteGroupPost
+      tags:
+        - groups
+      responses:
+        '200':
+          $ref: ../responses/groups/DeleteGroupPostResponse.yaml
+        '401':
+          $ref: ../responses/MissingCredentialsError.yaml
+        '404':
+          $ref: ../responses/groups/DeleteGroupPostResponse.yaml
+      security:
+        - authCookie: []
   '/groups/{groupId}/requests':
     parameters:
       - $ref: ../parameters.yaml#/groupId

--- a/openapi/components/requests/CreateGroupPostRequest.yaml
+++ b/openapi/components/requests/CreateGroupPostRequest.yaml
@@ -1,0 +1,29 @@
+title: CreateGroupPostRequest
+type: object
+properties:
+  title:
+    type: string
+    description: Post title
+    minLength: 1
+    example: "Event is starting soon!"
+  text:
+    type: string
+    description: Post text
+    minLength: 1
+    example: "Come join us for the event!"
+  imageId:
+    $ref: ../schemas/FileID.yaml
+  sendNotification:
+    type: boolean
+    description: Send notification to group members.
+    default: false
+    example: false
+  roleIds:
+    $ref: ../schemas/GroupRoleIDList.yaml
+  visibility:
+    $ref: ../schemas/GroupPostVisibility.yaml
+required:
+  - title
+  - text
+  - sendNotification
+  - visibility

--- a/openapi/components/responses/groups/DeleteGroupPostResponse.yaml
+++ b/openapi/components/responses/groups/DeleteGroupPostResponse.yaml
@@ -1,0 +1,11 @@
+description: Response after deleting a group post.
+content:
+  application/json:
+    schema:
+      $ref: ../../schemas/Success.yaml
+    examples:
+      Deleted Group Post:
+        value:
+          success:
+            message: Group Post was deleted!
+            status_code: 200

--- a/openapi/components/responses/groups/GroupPostResponse.yaml
+++ b/openapi/components/responses/groups/GroupPostResponse.yaml
@@ -1,0 +1,5 @@
+description: Returns a GroupPost object.
+content:
+  application/json:
+    schema:
+      $ref: ../../schemas/GroupPost.yaml

--- a/openapi/components/schemas/GroupPost.yaml
+++ b/openapi/components/schemas/GroupPost.yaml
@@ -3,28 +3,21 @@ type: object
 properties:
   id:
     $ref: ./NotificationID.yaml
-    nullable: true
   groupId:
     $ref: ./GroupID.yaml
-    nullable: true
   authorId:
     $ref: ./UserID.yaml
-    nullable: true
   editorId:
     $ref: ./UserID.yaml
     nullable: true
   visibility:
     $ref: ./GroupPostVisibility.yaml
-    nullable: false
   roleId:
     $ref: ./GroupRoleIDList.yaml
-    nullable: false
   title:
     type: string
-    nullable: true
   text:
     type: string
-    nullable: true
   imageId:
     $ref: ./FileID.yaml
     nullable: true
@@ -34,8 +27,6 @@ properties:
   createdAt:
     type: string
     format: date-time
-    nullable: true
   updatedAt:
     type: string
     format: date-time
-    nullable: true

--- a/openapi/components/schemas/GroupPost.yaml
+++ b/openapi/components/schemas/GroupPost.yaml
@@ -1,0 +1,41 @@
+title: GroupPost
+type: object
+properties:
+  id:
+    $ref: ./NotificationID.yaml
+    nullable: true
+  groupId:
+    $ref: ./GroupID.yaml
+    nullable: true
+  authorId:
+    $ref: ./UserID.yaml
+    nullable: true
+  editorId:
+    $ref: ./UserID.yaml
+    nullable: true
+  visibility:
+    $ref: ./GroupPostVisibility.yaml
+    nullable: false
+  roleId:
+    $ref: ./GroupRoleIDList.yaml
+    nullable: false
+  title:
+    type: string
+    nullable: true
+  text:
+    type: string
+    nullable: true
+  imageId:
+    $ref: ./FileID.yaml
+    nullable: true
+  imageUrl:
+    type: string
+    nullable: true
+  createdAt:
+    type: string
+    format: date-time
+    nullable: true
+  updatedAt:
+    type: string
+    format: date-time
+    nullable: true

--- a/openapi/components/schemas/GroupPostVisibility.yaml
+++ b/openapi/components/schemas/GroupPostVisibility.yaml
@@ -1,0 +1,6 @@
+example: public
+title: GroupPostVisibility
+type: string
+enum:
+  - group
+  - public


### PR DESCRIPTION
Hi, please review my homework.

Added two new paths into the specification.

1. /groups/{groupId}/posts
2. /groups/{groupId}/posts/{notificationId}

First one adds a GET and POST request for getting a list of posts from a group, and creating a new post. They are similar to the announcements functions, but perhaps hints that the "announcements" are becoming deprecated in the  near future. The announcements path still functions (partially), but the website's front end doesn't really reflect back anything useful.

The second path creates a DELETE request for removing a post. They use the notification ID system, which is interesting.

The POST and DELETE methods probably both have a 403 error attached to them, but I haven't been able to test this without going into a random group's posts to attempt (not wanting to get banned). My friends are not group owners.

Also, this part:
```
  roleId:
    $ref: ./GroupRoleIDList.yaml
    nullable: false
```

Is always an empty list or populated with role IDs, but I wasn't sure if an empty list is considered 'nullable'. 