### PR TITLE
Change user groups to LimitedGroup response.

### DIFF
--- a/openapi/components/paths/users.yaml
+++ b/openapi/components/paths/users.yaml
@@ -113,7 +113,7 @@ paths:
         - authCookie: []
       responses:
         '200':
-          $ref: ../responses/groups/LimitedGroupListResponse.yaml.yaml
+          $ref: ../responses/groups/LimitedGroupListResponse.yaml
         '401':
           $ref: ../responses/MissingCredentialsError.yaml
       operationId: getUserGroups

--- a/openapi/components/paths/users.yaml
+++ b/openapi/components/paths/users.yaml
@@ -113,7 +113,7 @@ paths:
         - authCookie: []
       responses:
         '200':
-          $ref: ../responses/groups/GroupListResponse.yaml
+          $ref: ../responses/groups/LimitedGroupListResponse.yaml.yaml
         '401':
           $ref: ../responses/MissingCredentialsError.yaml
       operationId: getUserGroups


### PR DESCRIPTION
Changed the /users/{userId}/groups response to a LimitedGroupListResponse.yaml since the returned schema is less than the Groups.yaml.

Example:
```
        "id": "gmem_adac4f98-2bc2-4055-a67b-0db0cdaf9bc5",
        "name": "Club Pnk",
        "shortCode": "PNK",
        "discriminator": "6939",
        "description": "Welcome to Club Pnk‚ the cutting-edge Australian-based virtual reality night club that is revolutionizing the nightlife scene․ \n\nAs the doors of the physical world close‚ our digital doors open wide‚ offering an immersive and unforgettable experience that transcends boundaries and defies limitations․\n\nClub Pnk beckons you into an electrifying environment‚ where you can lose yourself to the rhythm and connect with fellow partygoers from all corners of the globe․\n\nAs an Australian-based virtual reality night club‚ Club Pnk encapsulates the spirit of the land down under․",
        "iconId": "file_6da1b94b-7d46-4880-a28d-5a35701f56ec",
        "iconUrl": "https://api.vrchat.cloud/api/1/file/file_6da1b94b-7d46-4880-a28d-5a35701f56ec/1/file",
        "bannerId": "file_f6e0a3a8-f314-4210-bfd9-4e190009c4ac",
        "bannerUrl": "https://api.vrchat.cloud/api/1/file/file_f6e0a3a8-f314-4210-bfd9-4e190009c4ac/1/file",
        "privacy": "default",
        "lastPostCreatedAt": "2024-04-06T10:09:20.693Z",
        "ownerId": "usr_db3a4cd0-ee48-4818-a2cf-f55b5b1e583d",
        "memberCount": 877,
        "groupId": "grp_8dccbd68-cfa7-48fc-a07e-15f20e95088f",
        "memberVisibility": "visible",
        "isRepresenting": false,
        "mutualGroup": true,
        "lastPostReadAt": null
```
