### PR TITLE
FIX: User Groups is not LimitedGroups object

### DIFF
--- a/openapi/components/paths/users.yaml
+++ b/openapi/components/paths/users.yaml
@@ -113,7 +113,7 @@ paths:
         - authCookie: []
       responses:
         '200':
-          $ref: ../responses/groups/LimitedGroupListResponse.yaml
+          $ref: ../responses/users/LimitedUserGroupListResponse.yaml
         '401':
           $ref: ../responses/MissingCredentialsError.yaml
       operationId: getUserGroups

--- a/openapi/components/responses/users/LimitedUserGroupListResponse.yaml
+++ b/openapi/components/responses/users/LimitedUserGroupListResponse.yaml
@@ -1,0 +1,7 @@
+description: Returns a list of LimitedUserGroups objects.
+content:
+  application/json:
+    schema:
+      type: array
+      items:
+        $ref: ../../schemas/LimitedUserGroups.yaml

--- a/openapi/components/schemas/LimitedUserGroups.yaml
+++ b/openapi/components/schemas/LimitedUserGroups.yaml
@@ -1,0 +1,47 @@
+title: LimitedUserGroups
+type: object
+properties:
+  id:
+    $ref: ./GroupMemberID.yaml
+  name:
+    type: string
+  shortCode:
+    $ref: ./GroupShortCode.yaml
+  discriminator:
+    $ref: ./GroupDiscriminator.yaml
+  description:
+    type: string
+  iconId:
+    type: string
+    nullable: true
+  iconUrl:
+    type: string
+    nullable: true
+  bannerId:
+    type: string
+    nullable: true
+  bannerUrl:
+    type: string
+    nullable: true
+  privacy:
+    type: string
+  lastPostCreatedAt:
+    type: string
+    format: date-time
+    nullable: true
+  ownerId:
+    $ref: ./UserID.yaml
+  memberCount:
+    type: integer
+  groupId:
+    $ref: ./GroupID.yaml
+  memberVisibility:
+    type: string
+  isRepresenting:
+    type: boolean
+  mutualGroup:
+    type: boolean
+  lastPostReadAt:
+    type: string
+    format: date-time
+    nullable: true


### PR DESCRIPTION
As it turns out, querying for the user groups returns a very very slightly different object than LimitedGroup. Since the schema is different, changing the response into its own schema.