### PR TITLE
Add fields to LimitedUser, change fields in SentNotification, make CurrentUser.badges not required

### DIFF
--- a/openapi/components/requests/UpdateUserRequest.yaml
+++ b/openapi/components/requests/UpdateUserRequest.yaml
@@ -24,6 +24,10 @@ properties:
     type: array
     items:
       type: string
+  pronouns:
+    type: string
+    minLength: 0
+    maxLength: 32
   userIcon:
     type: string
     description: MUST be a valid VRChat /file/ url.

--- a/openapi/components/responses/notifications/SendNotificationResponse.yaml
+++ b/openapi/components/responses/notifications/SendNotificationResponse.yaml
@@ -11,5 +11,5 @@ content:
           senderUserId: usr_c1644b5b-3ca4-45b4-97c6-a2a0de70d469
           type: friendRequest
           message: ''
-          details: '{}'
+          details: {}
           created_at: '2021-01-01T00:00:00.000Z'

--- a/openapi/components/responses/notifications/SendNotificationResponse.yaml
+++ b/openapi/components/responses/notifications/SendNotificationResponse.yaml
@@ -7,7 +7,7 @@ content:
       Example Friend Request Response:
         value:
           id: frq_00000000-0000-0000-0000-000000000000
-          recieverUserId: usr_00000000-0000-0000-0000-000000000000
+          receiverUserId: usr_00000000-0000-0000-0000-000000000000
           senderUserId: usr_c1644b5b-3ca4-45b4-97c6-a2a0de70d469
           type: friendRequest
           message: ''

--- a/openapi/components/schemas/CurrentUser.yaml
+++ b/openapi/components/schemas/CurrentUser.yaml
@@ -181,7 +181,6 @@ required:
   - id
   - displayName
   - userIcon
-  - badges
   - bio
   - bioLinks
   - profilePicOverride

--- a/openapi/components/schemas/LimitedUser.yaml
+++ b/openapi/components/schemas/LimitedUser.yaml
@@ -2,10 +2,19 @@ description: ''
 properties:
   bio:
     type: string
+  bioLinks:
+    description: ' '
+    type: array  
+    items:
+      type: string
   currentAvatarImageUrl:
     $ref: ./CurrentAvatarImageUrl.yaml
   currentAvatarThumbnailImageUrl:
     $ref: ./CurrentAvatarThumbnailImageUrl.yaml
+  currentAvatarTags:
+    type: array
+    items:
+      $ref: ./Tag.yaml
   developerType:
     $ref: ./DeveloperType.yaml
   displayName:

--- a/openapi/components/schemas/SentNotification.yaml
+++ b/openapi/components/schemas/SentNotification.yaml
@@ -4,10 +4,8 @@ properties:
     format: date-time
     type: string
   details:
-    default: '{}'
-    description: '**NOTICE:** This is not a JSON object, this is a json **encoded** object, meaning you have to json-de-encode to get the NotificationDetail object depending on the NotificationType.'
     example: 'OneOf: {}, NotificationDetailInvite, NotificationDetailInviteResponse, NotificationDetailRequestInvite, NotificationDetailRequestInviteResponse, NotificationDetailVoteToKick'
-    type: string
+    type: object
   id:
     minLength: 1
     type: string
@@ -15,7 +13,7 @@ properties:
     description: ''
     example: This is a generated invite to VRChat Hub
     type: string
-  recieverUserId:
+  receiverUserId:
     $ref: ./UserID.yaml
   senderUserId:
     $ref: ./UserID.yaml
@@ -32,7 +30,7 @@ required:
   - details
   - id
   - message
-  - recieverUserId
+  - receiverUserId
   - senderUserId
   - type
 title: SentNotification

--- a/openapi/components/schemas/SentNotification.yaml
+++ b/openapi/components/schemas/SentNotification.yaml
@@ -4,7 +4,7 @@ properties:
     format: date-time
     type: string
   details:
-    example: 'OneOf: {}, NotificationDetailInvite, NotificationDetailInviteResponse, NotificationDetailRequestInvite, NotificationDetailRequestInviteResponse, NotificationDetailVoteToKick'
+    example: OneOf: {}, NotificationDetailInvite, NotificationDetailInviteResponse, NotificationDetailRequestInvite, NotificationDetailRequestInviteResponse, NotificationDetailVoteToKick
     type: object
   id:
     minLength: 1

--- a/openapi/components/schemas/SentNotification.yaml
+++ b/openapi/components/schemas/SentNotification.yaml
@@ -4,7 +4,14 @@ properties:
     format: date-time
     type: string
   details:
-    example: OneOf: {}, NotificationDetailInvite, NotificationDetailInviteResponse, NotificationDetailRequestInvite, NotificationDetailRequestInviteResponse, NotificationDetailVoteToKick
+    example:
+      OneOf:
+        - {}
+        - NotificationDetailInvite
+        - NotificationDetailInviteResponse
+        - NotificationDetailRequestInvite
+        - NotificationDetailRequestInviteResponse
+        - NotificationDetailVoteToKick
     type: object
   id:
     minLength: 1


### PR DESCRIPTION
CurrentUser: badge?
badge field is not required: https://github.com/vrchatapi/specification-test/blob/b55c7d639f4d11167cdc0195170494db90b61cec/data/requests/avatars/selectavatar-with-id.md

LimitedUser: +bioLinks, +currentAvatarTags

SentNotification:  recieverUserId -> receiverUserId, details: object (was string)
POST `/invite/myself/to/{worldid}:{instanceid}`:
```json
{
    "created_at": "2024-05-05T08:02:42.772Z",
    "details": {
        "worldId": "wrld_4cf554b4-430c-4f8f-b53e-1f294eed230b:80187~group(grp_9b1b2366-0eb6-41cb-9235-470b0db83f99)~groupAccessType(public)~region(us)",
        "worldName": "The Black Cat"
    },
    "id": "not_093fbb9f-5d71-47d3-995a-0032cda17450",
    "message": "This is a generated invite to The Black Cat",
    "receiverUserId": "usr_9664d091-ca57-43a5-8524-6a8f2a14de48",
    "senderUserId": "usr_9664d091-ca57-43a5-8524-6a8f2a14de48",
    "senderUsername": "Vinyarion",
    "type": "invite"
}
```