### PR TITLE
refactor(instance): separately define the instance region

### DIFF
--- a/openapi/components/requests/CreateInstanceRequest.yaml
+++ b/openapi/components/requests/CreateInstanceRequest.yaml
@@ -6,7 +6,7 @@ properties:
   type:
     $ref: ../schemas/InstanceType.yaml
   region:
-    $ref: ../schemas/Region.yaml
+    $ref: ../schemas/InstanceRegion.yaml
   ownerId:
     $ref: ../schemas/InstanceOwnerId.yaml
   roleIds:

--- a/openapi/components/schemas/Instance.yaml
+++ b/openapi/components/schemas/Instance.yaml
@@ -51,7 +51,7 @@ properties:
   platforms:
     $ref: ./InstancePlatforms.yaml
   region:
-    $ref: ./Region.yaml
+    $ref: ./InstanceRegion.yaml
   secureName:
     type: string
     minLength: 1

--- a/openapi/components/schemas/InstanceRegion.yaml
+++ b/openapi/components/schemas/InstanceRegion.yaml
@@ -1,0 +1,10 @@
+type: string
+title: InstanceRegion
+default: us
+example: us
+enum:
+  - us
+  - use
+  - eu
+  - jp
+description: Instance region


### PR DESCRIPTION
Separately define the instance region to explicitly enumerate the allowed instance regions.

This helps make it clear what types of regions are allowed when creating instances with the vrc api.
Example response when trying to create an instance with a region that isn't allowed:
```
{
	"error": {
		"message": "region must be one of ［＂us＂‚＂use＂‚＂eu＂‚＂jp＂］‚ not ＂usw＂",
		"status_code": 400
	}
}
```