### PR TITLE
fix(group): specify joinedAt is nullable

### DIFF
--- a/openapi/components/schemas/GroupLimitedMember.yaml
+++ b/openapi/components/schemas/GroupLimitedMember.yaml
@@ -23,6 +23,7 @@ properties:
   joinedAt:
     type: string
     format: date-time
+    nullable: true
   membershipStatus:
     $ref: ./GroupMemberStatus.yaml
   visibility:


### PR DESCRIPTION
Specify that joinedAt is nullable when a user is not a member when using the endpoint `/groups/{groupId}/members/{userId}`