### PR TITLE
Remove minimum length from assetUrl

### DIFF
--- a/openapi/components/schemas/UnityPackage.yaml
+++ b/openapi/components/schemas/UnityPackage.yaml
@@ -14,7 +14,6 @@ properties:
   id:
     $ref: ./UnityPackageID.yaml
   assetUrl:
-    minLength: 1
     type: string
     nullable: true
   assetUrlObject:


### PR DESCRIPTION
Occasionally, a VRC World object will produce UnityAsset's with empty (but not null) string: `""` assetURL values, which will trigger a validation error (at least on the Python SDK)

This PR removes the minimum character check for Unity Asset URL's

Related issue: https://github.com/vrchatapi/specification/issues/341