### PR TITLE
Remove md5 requirement breaking some requests on validation

### DIFF
--- a/openapi/components/schemas/FileData.yaml
+++ b/openapi/components/schemas/FileData.yaml
@@ -31,7 +31,6 @@ properties:
 required:
   - category
   - fileName
-  - md5
   - sizeInBytes
   - status
   - uploadId


### PR DESCRIPTION
Fixes #349 I believe.
FileData is only used in FileVersion as of now, so this shouldn't break anything else