### PR TITLE
Add new Group properties

### DIFF
--- a/openapi/components/schemas/Group.yaml
+++ b/openapi/components/schemas/Group.yaml
@@ -53,12 +53,20 @@ properties:
     type: array
     items:
       $ref: ./Tag.yaml
+  transferTargetId:
+    $ref: ./UserID.yaml
   galleries:
     description: ' '
     type: array
     items:
       $ref: ./GroupGallery.yaml
   createdAt:
+    type: string
+    format: date-time
+  updatedAt:
+    type: string
+    format: date-time
+  lastPostCreatedAt:
     type: string
     format: date-time
   onlineMemberCount:

--- a/openapi/components/schemas/GroupMyMember.yaml
+++ b/openapi/components/schemas/GroupMyMember.yaml
@@ -11,6 +11,13 @@ properties:
     type: array
     items:
       $ref: ./GroupRoleID.yaml
+  acceptedByDisplayName:
+    type: string
+  acceptedById:
+    $ref: ./UserID.yaml
+  createdAt:
+    type: string
+    format: date-time
   managerNotes:
     type: string
   membershipStatus:
@@ -34,6 +41,16 @@ properties:
   has2FA:
     type: boolean
     default: false
+  hasJoinedFromPurchase:
+    type: boolean
+    default: false
+  lastPostReadAt:
+    type: string
+    format: date-time
+  mRoleIds:
+    type: array
+    items:
+      type: string
   permissions:
     type: array
     items:


### PR DESCRIPTION
Please note, that I temporarily guessed the types of:
- myMember/lastPostReadAt
- myMember/acceptedById
- myMember/acceptedByDisplayName
- myMember/mRoleIds
- lastPostCreatedAt
- transferTargetId

When looking at the repsonse I get from https://vrchat.com/api/1/groups/{groupid} in the vrchat website, I can't find `transferTargetId`, `myMember/acceptedByDisplayName`, `myMember/acceptedById` or `myMember/hasJoinedFromPurchase`.