### PR TITLE
Add 403 mapping for getting Group members

### DIFF
--- a/openapi/components/paths/groups.yaml
+++ b/openapi/components/paths/groups.yaml
@@ -547,6 +547,8 @@ paths:
           $ref: ../responses/groups/GroupLimitedMemberResponse.yaml
         '401':
           $ref: ../responses/MissingCredentialsError.yaml
+        '403':
+          $ref: ../responses/groups/GroupNotMemberError.yaml
         '404':
           $ref: ../responses/groups/GroupNotFoundError.yaml
       security:


### PR DESCRIPTION
The endpoint can return multiple 403 errors:
  - You're not allowed to view membership details
  - You're not a member

However with the state of `oneOf` I just decided to put something there.
I hope that both responses can be parsed to an error regardless of the actual errormessage contents. 

Fixes: #350 