### PR TITLE
Add missing query-string `roleId` to `/groups/{groupId}/members`

### DIFF
--- a/openapi/components/parameters.yaml
+++ b/openapi/components/parameters.yaml
@@ -30,6 +30,13 @@ groupMemberSort:
   schema:
     $ref: ./schemas/GroupSearchSort.yaml
   description: The sort order of Group Member results
+groupMemberRoleFilter:
+  name: roleId
+  in: query
+  required: false
+  schema:
+    $ref: ./schemas/GroupRoleID.yaml
+  description: Only returns members with a specific groupRoleId
 order:
   name: order
   in: query

--- a/openapi/components/paths/groups.yaml
+++ b/openapi/components/paths/groups.yaml
@@ -523,6 +523,7 @@ paths:
         - $ref: ../parameters.yaml#/number
         - $ref: ../parameters.yaml#/offset
         - $ref: ../parameters.yaml#/groupMemberSort
+        - $ref: ../parameters.yaml#/groupMemberRoleFilter
       responses:
         '200':
           $ref: ../responses/groups/GroupMemberListResponse.yaml


### PR DESCRIPTION
Added the `roleId` query-string to `groups.yaml` and `parameters.yaml` for `/groups/{groupId}/members` since I noticed it wasn't documented.