### PR TITLE
Remove licenseGroup endpoint as it's admin only

### DIFF
--- a/openapi/components/codeSamples/economy.yaml
+++ b/openapi/components/codeSamples/economy.yaml
@@ -34,12 +34,6 @@
       source: >-
         curl -X GET "https://vrchat.com/api/1/subscriptions" \
              -b "auth={authCookie}"
-/licenseGroups:
-  get:
-    - lang: cURL
-      source: >-
-        curl -X GET "https://vrchat.com/api/1/licenseGroups" \
-             -b "auth={authCookie}"
 '/licenseGroups/{licenseGroupId}':
   get:
     - lang: cURL

--- a/openapi/components/paths.yaml
+++ b/openapi/components/paths.yaml
@@ -50,8 +50,6 @@
   $ref: "./paths/economy.yaml#/paths/~1auth~1user~1subscription"
 '/subscriptions':
   $ref: "./paths/economy.yaml#/paths/~1subscriptions"
-'/licenseGroups':
-  $ref: "./paths/economy.yaml#/paths/~1licenseGroups"
 '/licenseGroups/{licenseGroupId}':
   $ref: "./paths/economy.yaml#/paths/~1licenseGroups~1{licenseGroupId}"
 

--- a/openapi/components/paths/economy.yaml
+++ b/openapi/components/paths/economy.yaml
@@ -108,26 +108,6 @@ paths:
       tags:
         - economy
       description: 'List all existing Subscriptions. For example, "vrchatplus-monthly" and "vrchatplus-yearly".'
-  /licenseGroups:
-    get:
-      summary: List License Groups
-      operationId: getLicenseGroups
-      security:
-        - authCookie: []
-      x-codeSamples:
-        $ref: "../codeSamples/economy.yaml#/~1licenseGroups/get"
-      responses:
-        '200':
-          $ref: ../responses/economy/LicenseGroupListResponse.yaml
-        '401':
-          $ref: ../responses/MissingCredentialsError.yaml
-      tags:
-        - economy
-      description: |-
-        List all existing license groups.
-
-        **IMPLEMENTATION WARNING:** This endpoint currently return a text/plain array of seven nulls.
-      x-internal: true
   '/licenseGroups/{licenseGroupId}':
     parameters:
       - $ref: ../parameters.yaml#/licenseGroupId

--- a/openapi/components/responses/economy/LicenseGroupListResponse.yaml
+++ b/openapi/components/responses/economy/LicenseGroupListResponse.yaml
@@ -1,7 +1,0 @@
-description: Returns a list of LicenseGroup objects.
-content:
-  application/json:
-    schema:
-      type: array
-      items:
-        $ref: ../../schemas/LicenseGroup.yaml


### PR DESCRIPTION
```
returns 
{
    "error": {
        "message": "\"Invalid Admin Credentials\"",
        "status_code": 403
    }
}
```