### PR TITLE
Fix group posts api

### DIFF
--- a/openapi/components/paths/groups.yaml
+++ b/openapi/components/paths/groups.yaml
@@ -657,7 +657,7 @@ paths:
     get:
       summary: Get posts from a Group
       description: Get posts from a Group
-      operationId: getGroupPost
+      operationId: getGroupPosts
       tags:
         - groups
       parameters:
@@ -670,7 +670,7 @@ paths:
           description: See public posts only.
       responses:
         '200':
-          $ref: ../responses/groups/GroupPostResponse.yaml
+          $ref: ../responses/groups/GroupPostsResponse.yaml
         '401':
           $ref: ../responses/MissingCredentialsError.yaml
       security:

--- a/openapi/components/responses/groups/GroupPostsResponse.yaml
+++ b/openapi/components/responses/groups/GroupPostsResponse.yaml
@@ -1,0 +1,10 @@
+description: Returns a GroupPost Array.
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        posts:
+          type: array
+          items:
+            $ref: ../../schemas/GroupPost.yaml


### PR DESCRIPTION
Previous version doesnt work at all right now, technically breaking change due to name change but the old name was wrong