### PR TITLE
Added endpoints for licensed avatars, impostors, user tags, user persistence, badge visibility

### DIFF
--- a/openapi/components/codeSamples/avatars.yaml
+++ b/openapi/components/codeSamples/avatars.yaml
@@ -8,7 +8,7 @@
   get:
     - lang: cURL
       source: >-
-        curl -X GET "https://api.vrchat.cloud/api/1/licensed" \
+        curl -X GET "https://api.vrchat.cloud/api/1/avatars/licensed" \
              -b "auth={authCookie}"
 /avatars:
   get:

--- a/openapi/components/codeSamples/avatars.yaml
+++ b/openapi/components/codeSamples/avatars.yaml
@@ -4,6 +4,12 @@
       source: >-
         curl -X GET "https://api.vrchat.cloud/api/1/avatars/favorites?featured=true" \
              -b "auth={authCookie}"
+/avatars/licensed:
+  get:
+    - lang: cURL
+      source: >-
+        curl -X GET "https://api.vrchat.cloud/api/1/licensed" \
+             -b "auth={authCookie}"
 /avatars:
   get:
     - lang: cURL
@@ -45,7 +51,26 @@
   put:
     - lang: cURL
       source: >-
-        curl -X PUT "https://api.vrchat.cloud/api/1/avatars/{avatarId}/selectFallback"
+        curl -X PUT "https://api.vrchat.cloud/api/1/avatars/{avatarId}/selectFallback" \
+             -b "auth={authCookie}"
+'/avatars/{avatarId}/impostor/enqueue':
+  post:
+    - lang: cURL
+      source: >-
+        curl -X POST "https://api.vrchat.cloud/api/1/avatars/{avatarId}/impostor/enqueue" \
+             -b "auth={authCookie}"
+'/avatars/{avatarId}/impostor':
+  delete:
+    - lang: cURL
+      source: >-
+        curl -X DELETE "https://api.vrchat.cloud/api/1/avatars/{avatarId}/impostor" \
+             -b "auth={authCookie}"
+'/avatars/impostor/queue/stats':
+  get:
+    - lang: cURL
+      source: >-
+        curl -X GET "https://api.vrchat.cloud/api/1/avatars/impostor/queue/stats" \
+             -b "auth={authCookie}"
 '/users/{userId}/avatar':
   get:
     - lang: cURL

--- a/openapi/components/codeSamples/users.yaml
+++ b/openapi/components/codeSamples/users.yaml
@@ -54,9 +54,35 @@
       source: >-
         curl -X GET "https://api.vrchat.cloud/api/1/userNotes/{userNoteId}" \
              -b "auth={authCookie}"
+'/users/{userId}/addTags':
+  post:
+    - lang: cURL
+      source: >-
+        curl -X POST "https://api.vrchat.cloud/api/1/users/{userId}/addTags" \
+             -b "auth={authCookie}" \
+             --data '{"tags": [ "language_zxx" ] }'
+'/users/{userId}/removeTags':
+  post:
+    - lang: cURL
+      source: >-
+        curl -X POST "https://api.vrchat.cloud/api/1/users/{userId}/removeTags" \
+             -b "auth={authCookie}" \
+             --data '{"tags": [ "language_zxx" ] }'
 '/users/{userId}/instances/groups':
   get:
     - lang: cURL
       source: >-
         curl -X GET "https://api.vrchat.cloud/api/1/users/{userId}/instances/groups" \
+             -b "auth={authCookie}"
+'/users/{userId}/{worldId}/persist/exists':
+  get:
+    - lang: cURL
+      source: >-
+        curl -X GET "https://api.vrchat.cloud/api/1/users/{userId}/{worldId}/persist/exists" \
+             -b "auth={authCookie}"
+'/users/{userId}/{worldId}/persist':
+  delete:
+    - lang: cURL
+      source: >-
+        curl -X DELETE "https://api.vrchat.cloud/api/1/users/{userId}/{worldId}/persist" \
              -b "auth={authCookie}"

--- a/openapi/components/codeSamples/users.yaml
+++ b/openapi/components/codeSamples/users.yaml
@@ -68,6 +68,13 @@
         curl -X POST "https://api.vrchat.cloud/api/1/users/{userId}/removeTags" \
              -b "auth={authCookie}" \
              --data '{"tags": [ "language_zxx" ] }'
+'/users/{userId}/badges/{badgeId}':
+  post:
+    - lang: cURL
+      source: >-
+        curl -X POST "https://api.vrchat.cloud/api/1/users/{userId}/badges/{badgeId}" \
+             -b "auth={authCookie}" \
+             --data '{"hidden": true, "showcased": false }'
 '/users/{userId}/instances/groups':
   get:
     - lang: cURL

--- a/openapi/components/codeSamples/users.yaml
+++ b/openapi/components/codeSamples/users.yaml
@@ -69,10 +69,10 @@
              -b "auth={authCookie}" \
              --data '{"tags": [ "language_zxx" ] }'
 '/users/{userId}/badges/{badgeId}':
-  post:
+  put:
     - lang: cURL
       source: >-
-        curl -X POST "https://api.vrchat.cloud/api/1/users/{userId}/badges/{badgeId}" \
+        curl -X PUT "https://api.vrchat.cloud/api/1/users/{userId}/badges/{badgeId}" \
              -b "auth={authCookie}" \
              --data '{"hidden": true, "showcased": false }'
 '/users/{userId}/instances/groups':

--- a/openapi/components/parameters.yaml
+++ b/openapi/components/parameters.yaml
@@ -195,6 +195,13 @@ userNoteId:
   schema:
     type: string
   description: Must be a valid user note ID.
+badgeId:
+  name: badgeId
+  in: path
+  required: true
+  schema:
+    type: string
+  description: Must be a valid badge ID.
 usernameQuery:
   name: username
   in: query

--- a/openapi/components/paths.yaml
+++ b/openapi/components/paths.yaml
@@ -289,6 +289,8 @@
   $ref: "./paths/users.yaml#/paths/~1users~1{userId}~1addTags"
 "/users/{userId}/removeTags":
   $ref: "./paths/users.yaml#/paths/~1users~1{userId}~1removeTags"
+"/users/{userId}/badges/{badgeId}":
+  $ref: "./paths/users.yaml#/paths/~1users~1{userId}~1badges~1{badgeId}"
 "/users/{userId}/instances/groups":
   $ref: "./paths/users.yaml#/paths/~1users~1{userId}~1instances~1groups"
 "/users/{userId}/{worldId}/persist/exists":

--- a/openapi/components/paths.yaml
+++ b/openapi/components/paths.yaml
@@ -35,6 +35,14 @@
   $ref: "./paths/avatars.yaml#/paths/~1avatars~1{avatarId}~1selectFallback"
 "/avatars/favorites":
   $ref: "./paths/avatars.yaml#/paths/~1avatars~1favorites"
+"/avatars/licensed":
+  $ref: "./paths/avatars.yaml#/paths/~1avatars~1licensed"
+"/avatars/{avatarId}/impostor/enqueue":
+  $ref: "./paths/avatars.yaml#/paths/~1avatars~1{avatarId}~1impostor~1enqueue"
+"/avatars/impostor/queue/stats":
+  $ref: "./paths/avatars.yaml#/paths/~1avatars~1impostor~1queue~1stats"
+"/avatars/{avatarId}/impostor":
+  $ref: "./paths/avatars.yaml#/paths/~1avatars~1{avatarId}~1impostor"
 
 # economy
 
@@ -277,8 +285,16 @@
   $ref: "./paths/users.yaml#/paths/~1userNotes"
 "/userNotes/{userNoteId}":
   $ref: "./paths/users.yaml#/paths/~1userNotes~1{userNoteId}"
+"/users/{userId}/addTags":
+  $ref: "./paths/users.yaml#/paths/~1users~1{userId}~1addTags"
+"/users/{userId}/removeTags":
+  $ref: "./paths/users.yaml#/paths/~1users~1{userId}~1removeTags"
 "/users/{userId}/instances/groups":
   $ref: "./paths/users.yaml#/paths/~1users~1{userId}~1instances~1groups"
+"/users/{userId}/{worldId}/persist/exists":
+  $ref: "./paths/users.yaml#/paths/~1users~1{userId}~1{worldId}~1persist~1exists"
+"/users/{userId}/{worldId}/persist":
+  $ref: "./paths/users.yaml#/paths/~1users~1{userId}~1{worldId}~1persist"
 
 # worlds
 

--- a/openapi/components/paths/avatars.yaml
+++ b/openapi/components/paths/avatars.yaml
@@ -183,7 +183,7 @@ paths:
         $ref: "../codeSamples/avatars.yaml#/~1avatars~1{avatarId}/delete"
       responses:
         '200':
-          description: Operation succeeded.
+          $ref: ../responses/avatars/AvatarResponse.yaml
         '401':
           $ref: ../responses/MissingCredentialsError.yaml
         '404':

--- a/openapi/components/paths/avatars.yaml
+++ b/openapi/components/paths/avatars.yaml
@@ -56,6 +56,25 @@ paths:
         - $ref: ../parameters.yaml#/platform
         - $ref: ../parameters.yaml#/userIdAdmin
       description: Search and list favorited avatars by query filters.
+  /avatars/licensed:
+    get:
+      summary: List Licensed Avatars
+      tags:
+        - avatars
+      x-codeSamples:
+        $ref: "../codeSamples/avatars.yaml#/~1avatars~1licensed/get"
+      responses:
+        '200':
+          $ref: ../responses/avatars/AvatarListResponse.yaml
+        '401':
+          $ref: ../responses/MissingCredentialsError.yaml
+      operationId: getLicensedAvatars
+      security:
+        - authCookie: []
+      parameters:
+        - $ref: ../parameters.yaml#/number
+        - $ref: ../parameters.yaml#/offset
+      description: List licensed avatars.
   /avatars:
     get:
       summary: Search Avatars
@@ -164,7 +183,7 @@ paths:
         $ref: "../codeSamples/avatars.yaml#/~1avatars~1{avatarId}/delete"
       responses:
         '200':
-          $ref: ../responses/avatars/AvatarResponse.yaml
+          description: Operation succeeded.
         '401':
           $ref: ../responses/MissingCredentialsError.yaml
         '404':
@@ -214,6 +233,62 @@ paths:
       security:
         - authCookie: []
       description: Switches into that avatar as your fallback avatar.
+  '/avatars/{avatarId}/impostor/enqueue':
+    parameters:
+      - $ref: ../parameters.yaml#/avatarId
+    post:
+      summary: Enqueue Impostor generation
+      tags:
+        - avatars
+      x-codeSamples:
+        $ref: "../codeSamples/avatars.yaml#/~1avatars~1{avatarId}~1impostor~1enqueue/post"
+      responses:
+        '200':
+          $ref: ../responses/avatars/AvatarImpostorEnqueueResponse.yaml
+        '401':
+          $ref: ../responses/MissingCredentialsError.yaml
+        '404':
+          $ref: ../responses/avatars/AvatarNotFoundError.yaml
+      operationId: enqueueImpostor
+      security:
+        - authCookie: []
+      description: Enqueue Impostor generation for that avatar.
+  /avatars/impostor/queue/stats:
+    get:
+      summary: Get Impostor Queue Stats
+      tags:
+        - avatars
+      x-codeSamples:
+        $ref: "../codeSamples/avatars.yaml#/~1avatars~1impostor~1queue~1stats/get"
+      responses:
+        '200':
+          $ref: ../responses/avatars/AvatarImpostorQueueStatsResponse.yaml
+        '401':
+          $ref: ../responses/MissingCredentialsError.yaml
+      operationId: getImpostorQueueStats
+      security:
+        - authCookie: []
+      description: Gets service stats for queued impostor.
+  '/avatars/{avatarId}/impostor':
+    parameters:
+      - $ref: ../parameters.yaml#/avatarId
+    delete:
+      summary: Delete generated Impostor
+      tags:
+        - avatars
+      x-codeSamples:
+        $ref: "../codeSamples/avatars.yaml#/~1avatars~1{avatarId}~1impostor/delete"
+      responses:
+        '200':
+          $ref: ../responses/avatars/AvatarImpostorDeleteResponse.yaml
+        '401':
+          $ref: ../responses/MissingCredentialsError.yaml
+        '404':
+          $ref: ../responses/avatars/AvatarNotFoundError.yaml
+      operationId: deleteImpostor
+      security:
+        - authCookie: []
+      description: Delete generated Impostor for that avatar.
 tags:
   $ref: ../tags.yaml
 components:

--- a/openapi/components/paths/avatars.yaml
+++ b/openapi/components/paths/avatars.yaml
@@ -280,7 +280,7 @@ paths:
         $ref: "../codeSamples/avatars.yaml#/~1avatars~1{avatarId}~1impostor/delete"
       responses:
         '200':
-          $ref: ../responses/avatars/AvatarImpostorDeleteResponse.yaml
+          description: The Impostors generated for that avatar are deleted.
         '401':
           $ref: ../responses/MissingCredentialsError.yaml
         '404':

--- a/openapi/components/paths/users.yaml
+++ b/openapi/components/paths/users.yaml
@@ -274,6 +274,58 @@ paths:
           $ref: ../responses/MissingCredentialsError.yaml
       operationId: getUserNote
       description: Get a particular user note
+  '/users/{userId}/addTags':
+    parameters:
+      - $ref: ../parameters.yaml#/userId
+    post:
+      summary: Add User Tags
+      x-codeSamples:
+        $ref: ../codeSamples/users.yaml#/~1users~1{userId}~1addTags/post
+      description: Adds tags to the user's profile
+      operationId: addTags
+      tags:
+        - users
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../requests/ChangeUserTagsRequest.yaml
+      responses:
+        '200':
+          $ref: ../responses/users/CurrentUserResponse.yaml
+        '400':
+          $ref: ../responses/users/UserTagInvalidError.yaml
+        '401':
+          $ref: ../responses/MissingCredentialsError.yaml
+      security:
+        - authCookie: []
+  '/users/{userId}/removeTags':
+    parameters:
+      - $ref: ../parameters.yaml#/userId
+    post:
+      summary: Remove User Tags
+      x-codeSamples:
+        $ref: ../codeSamples/users.yaml#/~1users~1{userId}~1removeTags/post
+      description: Removes tags from the user's profile
+      operationId: removeTags
+      tags:
+        - users
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../requests/ChangeUserTagsRequest.yaml
+      responses:
+        '200':
+          $ref: ../responses/users/CurrentUserResponse.yaml
+        '400':
+          $ref: ../responses/users/UserTagInvalidError.yaml
+        '401':
+          $ref: ../responses/MissingCredentialsError.yaml
+      security:
+        - authCookie: []
   "/users/{userId}/instances/groups":
     parameters:
       - $ref: ../parameters.yaml#/userId
@@ -292,6 +344,50 @@ paths:
           $ref: ../responses/MissingCredentialsError.yaml
         '403':
           $ref: ../responses/users/UserMustBeOwnError.yaml
+      security:
+        - authCookie: []
+  '/users/{userId}/{worldId}/persist/exists':
+    parameters:
+      - $ref: ../parameters.yaml#/userId
+      - $ref: ../parameters.yaml#/worldId
+    get:
+      summary: Check User Persistence Exists
+      x-codeSamples:
+        $ref: ../codeSamples/users.yaml#/~1users~1{userId}~1{worldId}~1persist~1exists/get
+      description: Checks whether the user has persistence data for a given world
+      operationId: checkUserPersistenceExists
+      tags:
+        - users
+        - worlds
+      responses:
+        '200':
+          description: The user has persistence data for the given world.
+        '401':
+          $ref: ../responses/MissingCredentialsError.yaml
+        '404':
+          description: The user does not have persistence data for the given world.
+      security:
+        - authCookie: []
+  '/users/{userId}/{worldId}/persist':
+    parameters:
+      - $ref: ../parameters.yaml#/userId
+      - $ref: ../parameters.yaml#/worldId
+    delete:
+      summary: Delete User Persistence
+      x-codeSamples:
+        $ref: ../codeSamples/users.yaml#/~1users~1{userId}~1{worldId}~1persist/delete
+      description: Deletes the user's persistence data for a given world
+      operationId: deleteUserPersistence
+      tags:
+        - users
+        - worlds
+      responses:
+        '200':
+          description: The user's persistence data for the given world is deleted.
+        '401':
+          $ref: ../responses/MissingCredentialsError.yaml
+        '404':
+          description: The user does not have persistence data for the given world.
       security:
         - authCookie: []
 tags:

--- a/openapi/components/paths/users.yaml
+++ b/openapi/components/paths/users.yaml
@@ -326,6 +326,35 @@ paths:
           $ref: ../responses/MissingCredentialsError.yaml
       security:
         - authCookie: []
+  '/users/{userId}/badges/{badgeId}':
+    parameters:
+      - $ref: ../parameters.yaml#/userId
+      - $ref: ../parameters.yaml#/badgeId
+    post:
+      summary: Update User Badge
+      x-codeSamples:
+        $ref: ../codeSamples/users.yaml#/~1users~1{userId}~1badges~1{badgeId}/post
+      description: Updates a user's badge
+      operationId: updateBadge
+      tags:
+        - users
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../requests/UpdateUserBadgeRequest.yaml
+      responses:
+        '200':
+          description: The user's badge is updated.
+        '401':
+          $ref: ../responses/MissingCredentialsError.yaml
+        '403':
+          $ref: ../responses/users/UserMustBeOwnError.yaml
+        '404':
+          description: The user does not have the badge.
+      security:
+        - authCookie: []
   "/users/{userId}/instances/groups":
     parameters:
       - $ref: ../parameters.yaml#/userId

--- a/openapi/components/paths/users.yaml
+++ b/openapi/components/paths/users.yaml
@@ -330,10 +330,10 @@ paths:
     parameters:
       - $ref: ../parameters.yaml#/userId
       - $ref: ../parameters.yaml#/badgeId
-    post:
+    put:
       summary: Update User Badge
       x-codeSamples:
-        $ref: ../codeSamples/users.yaml#/~1users~1{userId}~1badges~1{badgeId}/post
+        $ref: ../codeSamples/users.yaml#/~1users~1{userId}~1badges~1{badgeId}/put
       description: Updates a user's badge
       operationId: updateBadge
       tags:

--- a/openapi/components/requests/ChangeUserTagsRequest.yaml
+++ b/openapi/components/requests/ChangeUserTagsRequest.yaml
@@ -1,0 +1,10 @@
+title: ChangeUserTagsRequest
+type: object
+properties:
+  tags:
+    description: 'The tags being added or removed.'
+    type: array  
+    items:
+      $ref: ../schemas/Tag.yaml
+required:
+  - tags

--- a/openapi/components/requests/UpdateUserBadgeRequest.yaml
+++ b/openapi/components/requests/UpdateUserBadgeRequest.yaml
@@ -1,0 +1,7 @@
+title: UpdateUserBadgeRequest
+type: object
+properties:
+  hidden:
+    type: boolean
+  showcased:
+    type: boolean

--- a/openapi/components/responses/avatars/AvatarImpostorEnqueueResponse.yaml
+++ b/openapi/components/responses/avatars/AvatarImpostorEnqueueResponse.yaml
@@ -1,0 +1,5 @@
+description: Returns a Service Status.
+content:
+  application/json:
+    schema:
+      $ref: ../../schemas/ServiceStatus.yaml

--- a/openapi/components/responses/avatars/AvatarImpostorQueueStatsResponse.yaml
+++ b/openapi/components/responses/avatars/AvatarImpostorQueueStatsResponse.yaml
@@ -1,0 +1,5 @@
+description: Returns a Service Queue Stats.
+content:
+  application/json:
+    schema:
+      $ref: ../../schemas/ServiceQueueStats.yaml

--- a/openapi/components/responses/users/UserBadgeUpdateResponse.yaml
+++ b/openapi/components/responses/users/UserBadgeUpdateResponse.yaml
@@ -1,0 +1,5 @@
+description: Returns a single LimitedBadge object.
+content:
+  application/json:
+    schema:
+      $ref: ../../schemas/LimitedBadge.yaml

--- a/openapi/components/responses/users/UserTagInvalidError.yaml
+++ b/openapi/components/responses/users/UserTagInvalidError.yaml
@@ -1,0 +1,5 @@
+description: Error response when a user attempts to add an invalid, restricted, or duplicate tag to their profile, attempts to add tags above the limit for their profile, or attempts to remove invalid, restricted, or absent tag from their profile.
+content:
+  application/json:
+    schema:
+      $ref: ../../schemas/Error.yaml

--- a/openapi/components/schemas/LimitedBadge.yaml
+++ b/openapi/components/schemas/LimitedBadge.yaml
@@ -1,0 +1,21 @@
+title: LimitedBadge
+type: object
+properties:
+  assignedAt:
+    type: string
+    format: date-time
+  badgeId:
+    $ref: ./BadgeID.yaml
+  hidden:
+    type: boolean
+  showcased:
+    type: boolean
+  updatedAt:
+    type: string
+    format: date-time
+required:
+  - assignedAt
+  - badgeId
+  - hidden
+  - showcased
+  - updatedAt

--- a/openapi/components/schemas/ServiceQueueStats.yaml
+++ b/openapi/components/schemas/ServiceQueueStats.yaml
@@ -1,0 +1,8 @@
+title: ServiceQueueStats
+type: object
+description: "Statistics about the user's currently queued service request"
+properties:
+  estimatedServiceDurationSeconds:
+    type: integer
+required:
+  - estimatedServiceDurationSeconds

--- a/openapi/components/schemas/ServiceStatus.yaml
+++ b/openapi/components/schemas/ServiceStatus.yaml
@@ -1,0 +1,41 @@
+title: ServiceStatus
+type: object
+description: 'Status information for a service request'
+properties:
+  created_at:
+    format: date-time
+    type: string
+  id:
+    description: 'The id of this service, NOT the id of the thing this service was requested for.'
+    type: string
+  progress:
+    type: array
+    items:
+      type: object
+  requesterUserId:
+    description: 'The id of the user who requested this service.'
+    $ref: ./UserID.yaml
+  state:
+    type: string
+  subjectId:
+    description: 'The id of the thing this service was requested for.'
+    type: string
+  subjectType:
+    description: 'The kind of the thing this service was requested for.'
+    type: string
+  type:
+    description: 'The kind of service that was requested.'
+    type: string
+  updated_at:
+    format: date-time
+    type: string
+required:
+  - created_at
+  - id
+  - progress
+  - requesterUserId
+  - state
+  - subjectId
+  - subjectType
+  - type
+  - updated_at


### PR DESCRIPTION
`GET /avatars/licensed`
`POST /avatars/{avatarId}/impostor/enqueue`
`DELETE /avatars/{avatarId}/impostor`
`GET /avatars/impostor/queue/stats`
`POST /users/{userId}/addTags`
`POST /users/{userId}/removeTags`
`GET /users/{userId}/{worldId}/persist/exists`
`DELETE /users/{userId}/{worldId}/persist`
`POST /users/{userId}/badges/{badgeId}`
Addresses #423