### PR TITLE
Add Instance Creation properties and Content Settings properties

### DIFF
--- a/openapi/components/requests/CreateInstanceRequest.yaml
+++ b/openapi/components/requests/CreateInstanceRequest.yaml
@@ -34,6 +34,17 @@ properties:
   inviteOnly:
     type: boolean
     default: false
+  ageGate:
+    type: boolean
+    default: false
+  instancePersistenceEnabled:
+    type: boolean
+    nullable: true
+  displayName:
+    type: string
+    nullable: true
+  contentSettings:
+    $ref: ../schemas/InstanceContentSettings.yaml
 required:
   - worldId
   - type

--- a/openapi/components/schemas/FavoritedWorld.yaml
+++ b/openapi/components/schemas/FavoritedWorld.yaml
@@ -17,6 +17,8 @@ properties:
   created_at:
     format: date-time
     type: string
+  defaultContentSettings:
+    $ref: ./InstanceContentSettings.yaml
   favorites:
     default: 0
     example: 12024

--- a/openapi/components/schemas/Instance.yaml
+++ b/openapi/components/schemas/Instance.yaml
@@ -25,6 +25,8 @@ properties:
     minLength: 1
     deprecated: true
     description: Always returns "unknown".
+  contentSettings:
+    $ref: ./InstanceContentSettings.yaml
   displayName:
     type: string
     nullable: true
@@ -137,6 +139,7 @@ required:
   - canRequestInvite
   - capacity
   - clientNumber
+  - contentSettings
   - displayName
   - full
   - id

--- a/openapi/components/schemas/InstanceContentSettings.yaml
+++ b/openapi/components/schemas/InstanceContentSettings.yaml
@@ -1,0 +1,20 @@
+description: 
+title: InstanceContentSettings
+type: object
+properties:
+  drones:
+    default: true
+    type: boolean
+  emoji:
+    default: true
+    type: boolean
+  pedestals:
+    default: true
+    type: boolean
+  prints:
+    default: true
+    type: boolean
+  stickers:
+    default: true
+    type: boolean
+required:

--- a/openapi/components/schemas/LimitedWorld.yaml
+++ b/openapi/components/schemas/LimitedWorld.yaml
@@ -14,6 +14,8 @@ properties:
   created_at:
     format: date-time
     type: string
+  defaultContentSettings:
+    $ref: ./InstanceContentSettings.yaml
   favorites:
     default: 0
     example: 12024

--- a/openapi/components/schemas/World.yaml
+++ b/openapi/components/schemas/World.yaml
@@ -16,6 +16,8 @@ properties:
   created_at:
     format: date-time
     type: string
+  defaultContentSettings:
+    $ref: ./InstanceContentSettings.yaml
   description:
     minLength: 0
     type: string


### PR DESCRIPTION
Covers #444 but has specific properties with types as opposed to catch-all `object`