### PR TITLE
Clarify endpoint descriptions for "Respond Invite" and "Respond Invite with Photo" 

### DIFF
--- a/openapi/components/paths/invite.yaml
+++ b/openapi/components/paths/invite.yaml
@@ -234,7 +234,11 @@ paths:
       operationId: respondInvite
       security:
         - authCookie: []
-      description: 'Respond to an invite request by sending a world invite to the requesting user. `:notificationId` is the ID of the requesting notification.'
+      description: |-
+        Respond to an invite or invite request without accepting it. `:notificationId` is the ID of the requesting notification.
+
+        In case the notification being replied to is an invite, the `responseSlot` refers to a response message from the the `message` collection.
+        In case the notification is an invite request, it will refer to one from the `requestResponse` collection instead.
       requestBody:
         required: true
         content:
@@ -259,7 +263,11 @@ paths:
       operationId: respondInviteWithPhoto
       security:
         - authCookie: []
-      description: 'Respond with photo to an invite request by sending a world invite to the requesting user. `:notificationId` is the ID of the requesting notification.'
+      description: |-
+        Respond with photo to an invite or invite request without accepting it. `:notificationId` is the ID of the requesting notification.
+
+        In case the notification being replied to is an invite, the `responseSlot` refers to a response message from the the `message` collection.
+        In case the notification is an invite request, it will refer to one from the `requestResponse` collection instead.'
       requestBody:
         required: true
         content:


### PR DESCRIPTION
- Fixes the current endpoint descriptions incorrectly suggesting these endpoints send out world invites.
- Adds some additional context regarding the `responseSlot` parameter, and what message will be used. 

That last one _would_ probably better fit as a description on the body / property itself, however swagger nor rapidoc seem to render these for request bodies in multipart requests. Or at least, I could not get them to, so I've put it in the endpoint description for both to stay consistent.