### PR TITLE
Add image file downloads

### DIFF
--- a/openapi/components/responses/files/RawFileResponse.yaml
+++ b/openapi/components/responses/files/RawFileResponse.yaml
@@ -1,1 +1,6 @@
 description: Raw file
+content:
+  image/*:
+    schema:
+      type: string
+      format: binary


### PR DESCRIPTION
Closes #460 

Right now only does image because I have not been able to download vrca/unitypackage, and I dont think they want us to be able to using the api. and for now image is better than nothing anyways.
