### PR TITLE
Add missing world query params

### DIFF
--- a/openapi/components/parameters.yaml
+++ b/openapi/components/parameters.yaml
@@ -251,6 +251,20 @@ platform:
   schema:
     type: string
   description: The platform the asset supports.
+noplatform:
+  name: noplatform
+  in: query
+  required: false
+  schema:
+    type: string
+  description: The platform the asset does not support.
+avatarSpecific:
+  name: avatarSpecific
+  in: query
+  required: false
+  schema:
+    type: boolean
+  description: Only search for avatar worlds.
 tag:
   name: tag
   in: query

--- a/openapi/components/paths/worlds.yaml
+++ b/openapi/components/paths/worlds.yaml
@@ -39,7 +39,9 @@ paths:
         - $ref: ../parameters.yaml#/maxUnityVersion
         - $ref: ../parameters.yaml#/minUnityVersion
         - $ref: ../parameters.yaml#/platform
+        - $ref: ../parameters.yaml#/noplatform
         - $ref: ../parameters.yaml#/fuzzy
+        - $ref: ../parameters.yaml#/avatarSpecific
       description: Search and list any worlds by query filters.
     post:
       summary: Create World

--- a/openapi/components/paths/worlds.yaml
+++ b/openapi/components/paths/worlds.yaml
@@ -88,6 +88,7 @@ paths:
         - $ref: ../parameters.yaml#/maxUnityVersion
         - $ref: ../parameters.yaml#/minUnityVersion
         - $ref: ../parameters.yaml#/platform
+        - $ref: ../parameters.yaml#/noplatform
       description: Search and list currently Active worlds by query filters.
   /worlds/recent:
     get:


### PR DESCRIPTION
Added 2 missing world query params
avatarSpecific: search for avatar specific worlds (or exclude them) <- boolean (can be seen on the "avatar worlds" category in vrchats website)
noplatform: exclude this platform <- string (you can see this in use for the category "spotlight pc")


there are two other params that i know of, too
releaseStatus (may be worth adding potentially)
organization (unsure if worth adding, ive only ever seen it be "vrchat")
I figured id mention them just for reference

I did test these on the worlds/recents endpoint but they have no effect like most other tags. avatarSpecific also didnt seem to work on worlds/active