### PR TITLE
Rename messageSlot to requestSlot in requestInviteRequest

### DIFF
--- a/openapi/components/requests/RequestInviteRequest.yaml
+++ b/openapi/components/requests/RequestInviteRequest.yaml
@@ -1,7 +1,7 @@
 title: RequestInviteRequest
 type: object
 properties:
-  messageSlot:
+  requestSlot:
     type: integer
     minimum: 0
     maximum: 11


### PR DESCRIPTION
Addresses #477

Sorry for duplicate, apparently renaming branch from the github default closes the pr