### PR TITLE
Make profilePicOverride optional for limited user objects

### DIFF
--- a/openapi/components/schemas/LimitedUserFriend.yaml
+++ b/openapi/components/schemas/LimitedUserFriend.yaml
@@ -74,8 +74,6 @@ required:
   - last_activity
   - last_mobile
   - platform
-  - profilePicOverride
-  - profilePicOverrideThumbnail
   - status
   - statusDescription
   - tags

--- a/openapi/components/schemas/LimitedUserInstance.yaml
+++ b/openapi/components/schemas/LimitedUserInstance.yaml
@@ -83,8 +83,6 @@ required:
   - last_platform
   - last_activity
   - last_mobile
-  - profilePicOverride
-  - profilePicOverrideThumbnail
   - pronouns
   - state
   - status

--- a/openapi/components/schemas/LimitedUserSearch.yaml
+++ b/openapi/components/schemas/LimitedUserSearch.yaml
@@ -49,7 +49,6 @@ required:
   - id
   - isFriend
   - last_platform
-  - profilePicOverride
   - status
   - statusDescription
   - tags


### PR DESCRIPTION
> DioException [unknown]: null Error: CheckedFromJsonException Could not create `LimitedUserFriend`. There is a problem with "profilePicOverride". Required keys are missing: profilePicOverride.

This came from crashlytics. Since I don't have an account with the issue, I can't be certain that these fields are optional on all the LimitedUser objects, but it's safer to assume they can be.