### PR TITLE
Make currentAvatarImageUrl optional on LimitedUserFriend

### DIFF
--- a/openapi/components/schemas/LimitedUserFriend.yaml
+++ b/openapi/components/schemas/LimitedUserFriend.yaml
@@ -61,7 +61,6 @@ properties:
   userIcon:
     type: string
 required:
-  - currentAvatarImageUrl
   - developerType
   - displayName
   - friendKey


### PR DESCRIPTION
Should we make this field optional on the other limited user objects as well?

<img width="2370" height="774" alt="image" src="https://github.com/user-attachments/assets/f7f433a3-7830-4883-9e3c-1a3173d4d6a2" />
