### PR TITLE
Fix PlayerModerationType schema and update query

### DIFF
--- a/openapi/components/paths/playermoderation.yaml
+++ b/openapi/components/paths/playermoderation.yaml
@@ -50,18 +50,18 @@ paths:
         - authCookie: []
       parameters:
         - schema:
-            type: string
+            $ref: ../schemas/PlayerModerationType.yaml
           in: query
           name: type
-          description: 'Must be one of PlayerModerationType, except unblock. Unblocking simply removes a block.'
+          description: Must be one of PlayerModerationType.
         - schema:
-            type: string
+            $ref: ../schemas/UserID.yaml
           in: query
           name: sourceUserId
           description: Must be valid UserID. Trying to view someone else's moderations results with "Can't view someone else's player moderations" error.
           x-internal: true
         - schema:
-            type: string
+            $ref: ../schemas/UserID.yaml
           in: query
           name: targetUserId
           description: Must be valid UserID.

--- a/openapi/components/schemas/PlayerModerationType.yaml
+++ b/openapi/components/schemas/PlayerModerationType.yaml
@@ -1,10 +1,13 @@
 type: string
 default: unmute
 enum:
-  - mute
-  - unmute
   - block
-  - unblock
+  - mute
+  - muteChat
+  - unmute
+  - unmuteChat
+  - hideAvatar
+  - showAvatar
   - interactOn
   - interactOff
 example: unmute


### PR DESCRIPTION
Fix `PlayerModerationType` schema and update query to use schema instead of string type

Resolves #493