### PR TITLE
Add missing instance region

### DIFF
--- a/openapi/components/schemas/InstanceRegion.yaml
+++ b/openapi/components/schemas/InstanceRegion.yaml
@@ -7,5 +7,6 @@ enum:
   - unknown
   - us
   - use
+  - usw
 default: us
 example: us


### PR DESCRIPTION
<img width="1214" height="455" alt="Screenshot 2025-12-02 at 4 00 53 PM" src="https://github.com/user-attachments/assets/7c8a047b-0c2e-4b40-a1d9-d068227d36e1" />

Should we remove InstanceRegion and just use Region instead?