### PR TITLE
Add MIMEType application/x-prop

### DIFF
--- a/openapi/components/schemas/MIMEType.yaml
+++ b/openapi/components/schemas/MIMEType.yaml
@@ -4,6 +4,7 @@ enum:
   - application/gzip
   - application/octet-stream
   - application/x-avatar
+  - application/x-prop
   - application/x-rsync-delta
   - application/x-rsync-signature
   - application/x-world


### PR DESCRIPTION
Example:
`GET https://vrchat.com/api/1/file/file_c991c050-8b43-4046-8182-24d068524ac5`
returns
```json
{
  "extension": ".vrcp",
  "id": "file_c991c050-8b43-4046-8182-24d068524ac5",
  "mimeType": "application/x-prop",
  "name": "Prop - DroneCube - Asset bundle - 2022․3․22f1_4_standalonewindows_Release",
  "ownerId": "8JoV9XEdpo",
  "tags": [],
  "versions": [
    ...
  ]
}
```