### PR TITLE
Add new 'group-instance-bypass-avatar-performance' permission to GroupPermissions schema

### DIFF
--- a/openapi/components/schemas/GroupPermissions.yaml
+++ b/openapi/components/schemas/GroupPermissions.yaml
@@ -11,6 +11,7 @@ enum:
   - group-galleries-manage
   - group-instance-age-gated-create
   - group-instance-announcement-create
+  - group-instance-bypass-avatar-performance
   - group-instance-calendar-link
   - group-instance-join
   - group-instance-manage
@@ -39,6 +40,7 @@ x-enum-varnames:
   - group_galleries_manage
   - group_instance_age_gated_create
   - group_instance_announcement_create
+  - group_instance_bypass_avatar_performance
   - group_instance_calendar_link
   - group_instance_join
   - group_instance_manage


### PR DESCRIPTION
Includes the new permission value in the enum and its variable name list, expanding group permission capabilities related to avatar performance bypass.
