### PR TITLE
Add Discord friend connections and shared connections opt-out fields

### DIFF
--- a/openapi/components/requests/UpdateUserRequest.yaml
+++ b/openapi/components/requests/UpdateUserRequest.yaml
@@ -25,6 +25,9 @@ properties:
     description: MUST specify currentPassword as well to change display name
   email:
     type: string
+  hasDiscordFriendsOptOut:
+    type: boolean
+    description: Opt out of the Discord Friend Connections feature
   hasSharedConnectionsOptOut:
     type: boolean
     description: Opt out of the Mutuals feature

--- a/openapi/components/schemas/CurrentUser.yaml
+++ b/openapi/components/schemas/CurrentUser.yaml
@@ -102,6 +102,8 @@ properties:
     type: boolean
   hasPendingEmail:
     type: boolean
+  hasSharedConnectionsOptOut:
+    type: boolean
   hideContentFilterSettings:
     type: boolean
   homeLocation:

--- a/openapi/components/schemas/CurrentUser.yaml
+++ b/openapi/components/schemas/CurrentUser.yaml
@@ -94,6 +94,8 @@ properties:
     type: string
   hasBirthday:
     type: boolean
+  hasDiscordFriendsOptOut:
+    type: boolean
   hasEmail:
     type: boolean
   hasLoggedInFromClient:


### PR DESCRIPTION
Adds the `hasDiscordFriendsOptOut` field to the `UpdateUserRequest` and `CurrentUser` schemas, and adds the `hasSharedConnectionsOptOut` (Mutuals feature) field to `CurrentUser`. 

`hasDiscordFriendsOptOut` field corresponds to the "Show Discord Friend Connections" privacy toggle on the profile settings page.

<img width="1321" height="319" alt="image" src="https://github.com/user-attachments/assets/ec48eae4-6891-4488-b801-3c49c8353152" />

Note: ~~I chose not to add it to `CurrentUser` because `hasDiscordFriendsOptOut` wasn't returned by `GET /auth/user` on one of my accounts until I set it via a `PUT` request. It seems inconsistent, so I didn't want to add it on `CurrentUser` yet.~~ From my testing the keys likely don't exist in the `GET` response until the user changes the setting at least once.