### PR TITLE
Prevent percent-encoding on InstanceID

### DIFF
--- a/openapi/components/schemas/InstanceID.yaml
+++ b/openapi/components/schemas/InstanceID.yaml
@@ -1,4 +1,4 @@
 title: InstanceID
-type: string
+type: password
 description: InstanceID can be "offline" on User profiles if you are not friends with that user and "private" if you are friends and user is in private instance.
 example: 12345~hidden(usr_c1644b5b-3ca4-45b4-97c6-a2a0de70d469)~region(eu)~nonce(27e8414a-59a0-4f3d-af1f-f27557eb49a2)


### PR DESCRIPTION
This PR fixes an issue with url encoding of InstanceID in URLs. 

The VRChat API does not accept percent-encoded variants of InstanceID, specifically the characters `~()`. This causes an error when attempting the following API call:
```
https://api.vrchat.cloud/api/1/instances/wrld_28aab3e4-953f-4c85-9223-ef29a0873a6e:31124%7Egroup%28grp_b2a19685-c53e-4c5a-9503-744a5373bf2c%29%7EgroupAccessType%28plus%29%7Eregion%28use%29/shortName
```
```json
{"error":{"message":"\"malformed url\"","status_code":400,"waf_code":26497}}
```

When using the raw string without encoding, the API yields a `200` response as expected. 
```
https://vrchat.com/api/1/instances/wrld_28aab3e4-953f-4c85-9223-ef29a0873a6e:31124~group(grp_b2a19685-c53e-4c5a-9503-744a5373bf2c)~groupAccessType(plus)~region(use)/shortName
```
The workaround I found for this, is to set the schema type to `password` instead of `string`. This skips the `urlencode` call inside of the SDK. The Rust template only does URL encoding for the string type, as is shown [here](https://github.com/OpenAPITools/openapi-generator/blob/ee7c9ff01d0ea6750877afda969b8f3439520aeb/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache#L156). A bit ugly, but it works. 

More testing is needed before merging this fix, as I have only tested generation of the Rust SDK. 