### PR TITLE
typos

### DIFF
--- a/openapi/components/paths/economy.yaml
+++ b/openapi/components/paths/economy.yaml
@@ -719,7 +719,7 @@ paths:
       - $ref: ../parameters.yaml#/subscriptionId
     get:
       operationId: getUserCreditsEligible
-      summary: Get User Credits Eligiblity
+      summary: Get User Credits Eligibility
       description: Get the user's eligibility status for subscriptions based on available credits.
       tags:
         - economy
@@ -736,7 +736,7 @@ paths:
       - $ref: ../parameters.yaml#/steamId
     get:
       operationId: getUserSubscriptionEligible
-      summary: Get User Subscription Eligiblity
+      summary: Get User Subscription Eligibility
       description: Get the user's eligibility status for subscriptions.
       tags:
         - economy

--- a/openapi/components/paths/favorites.yaml
+++ b/openapi/components/paths/favorites.yaml
@@ -75,7 +75,7 @@ paths:
         - $ref: ../parameters.yaml#/offset
         - $ref: ../parameters.yaml#/userIdAdmin
         - name: ownerId
-          description: The owner of whoms favorite groups to return. Must be a UserID.
+          description: The owner whose favorite groups to return. Must be a UserID.
           in: query
           schema:
             type: string

--- a/openapi/components/paths/files.yaml
+++ b/openapi/components/paths/files.yaml
@@ -245,7 +245,7 @@ paths:
 
         **Version Note:** Version 0 is always when the file was created. The real data is usually always located in version 1 and up.
 
-        **Extension Note:** Files are not guaranteed to have a file extensions. UnityPackage files tends to have it, images through this endpoint do not. You are responsible for appending file extension from the `extension` field when neccesary.
+        **Extension Note:** Files are not guaranteed to have a file extensions. UnityPackage files tends to have it, images through this endpoint do not. You are responsible for appending file extension from the `extension` field when necessary.
       tags:
         - files
       security:

--- a/openapi/components/paths/groups.yaml
+++ b/openapi/components/paths/groups.yaml
@@ -1106,7 +1106,7 @@ paths:
     post:
       operationId: initiateOrAcceptGroupTransfer
       summary: Initiate or Accept Group Transfer
-      description: To initiate, must be logged in as the current owner and specify the transferTargetId in the body. To accept, must be logged in as the user targetted by a pending transfer, no body is required.
+      description: To initiate, must be logged in as the current owner and specify the transferTargetId in the body. To accept, must be logged in as the user targeted by a pending transfer, no body is required.
       tags:
         - groups
       requestBody:

--- a/openapi/components/paths/notifications.yaml
+++ b/openapi/components/paths/notifications.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: notifications
-  description: Notifiations Docs
+  description: Notifications Docs
   version: "1.0"
 paths:
   /auth/user/notifications:

--- a/openapi/components/paths/playermoderation.yaml
+++ b/openapi/components/paths/playermoderation.yaml
@@ -10,7 +10,7 @@ info:
 
     ## Implementation details
 
-    There are three different user-targetted permission options:
+    There are three different user-targeted permission options:
 
     - Mode 1: interactOn/unmute/unblock
     - Mode 2: interactOff/mute/block
@@ -32,7 +32,7 @@ info:
 
     As of October 2022, `showAvatar` and `hideAvatar` has been moved to local storage.
     Sending these types to the API will result in a 200 OK response, but the API will **not** store them.
-    More information is avaiable on VRChat's official [documentation on Local Storage](https://docs.vrchat.com/docs/local-vrchat-storage).
+    More information is available on VRChat's official [documentation on Local Storage](https://docs.vrchat.com/docs/local-vrchat-storage).
   version: "1.0"
 paths:
   /auth/user/playermoderations:

--- a/openapi/components/requests/RegisterUserAccountRequest.yaml
+++ b/openapi/components/requests/RegisterUserAccountRequest.yaml
@@ -22,7 +22,7 @@ properties:
     minLength: 8
   subscribe:
     type: boolean
-    description: Whether to recieve promotional emails
+    description: Whether to receive promotional emails
   username:
     type: string
     description: Display Name / Username (Username is a sanitized version)

--- a/openapi/components/responses/avatars/AvatarSeeOtherUserFavoritesError.yaml
+++ b/openapi/components/responses/avatars/AvatarSeeOtherUserFavoritesError.yaml
@@ -1,4 +1,4 @@
-description: Error response when trying to see favourited avatars of another user without sufficient admin permissions.
+description: Error response when trying to see favorited avatars of another user without sufficient admin permissions.
 content:
   application/json:
     examples:

--- a/openapi/components/responses/instances/InstanceNotFoundError.yaml
+++ b/openapi/components/responses/instances/InstanceNotFoundError.yaml
@@ -1,4 +1,4 @@
-description: Error response due to non existant instance
+description: Error response due to non existent instance
 content:
   application/json:
     examples:

--- a/openapi/components/responses/invite/InviteMessageNoEntryForSlotError.yaml
+++ b/openapi/components/responses/invite/InviteMessageNoEntryForSlotError.yaml
@@ -1,4 +1,4 @@
-description: Error response when trying to reset an Invite Message whos slot doesn't exist.
+description: Error response when trying to reset an Invite Message whose slot doesn't exist.
 content:
   application/json:
     examples:

--- a/openapi/components/responses/invite/InviteMustBeFriendsError.yaml
+++ b/openapi/components/responses/invite/InviteMustBeFriendsError.yaml
@@ -1,4 +1,4 @@
-description: Error response when trying to invite someome whom you are not friends with.
+description: Error response when trying to invite someone whom you are not friends with.
 content:
   application/json:
     examples:

--- a/openapi/components/responses/notifications/NotificationListResponse.yaml
+++ b/openapi/components/responses/notifications/NotificationListResponse.yaml
@@ -1,4 +1,4 @@
-description: Returns a list of Notifcation objects.
+description: Returns a list of Notification objects.
 content:
   application/json:
     schema:

--- a/openapi/components/responses/notifications/NotificationResponse.yaml
+++ b/openapi/components/responses/notifications/NotificationResponse.yaml
@@ -1,4 +1,4 @@
-description: Returns a single Notifcation object.
+description: Returns a single Notification object.
 content:
   application/json:
     examples:

--- a/openapi/components/responses/notifications/NotificationV2ListResponse.yaml
+++ b/openapi/components/responses/notifications/NotificationV2ListResponse.yaml
@@ -1,4 +1,4 @@
-description: Returns a list of NotifcationV2 objects.
+description: Returns a list of NotificationV2 objects.
 content:
   application/json:
     schema:

--- a/openapi/components/responses/notifications/NotificationV2Response.yaml
+++ b/openapi/components/responses/notifications/NotificationV2Response.yaml
@@ -1,4 +1,4 @@
-description: Returns a single NotifcationV2 object.
+description: Returns a single NotificationV2 object.
 content:
   application/json:
     schema:

--- a/openapi/components/responses/notifications/SendNotificationResponse.yaml
+++ b/openapi/components/responses/notifications/SendNotificationResponse.yaml
@@ -1,4 +1,4 @@
-description: Returns a single SentNotifcation object.
+description: Returns a single SentNotification object.
 content:
   application/json:
     examples:

--- a/openapi/components/responses/worlds/WorldCreateNotAllowedYetError.yaml
+++ b/openapi/components/responses/worlds/WorldCreateNotAllowedYetError.yaml
@@ -1,4 +1,4 @@
-description: Error response when trying create a world without having the neccesary Trust rank yet.
+description: Error response when trying create a world without having the necessary Trust rank yet.
 content:
   application/json:
     examples:

--- a/openapi/components/responses/worlds/WorldSeeOtherUserFavoritesError.yaml
+++ b/openapi/components/responses/worlds/WorldSeeOtherUserFavoritesError.yaml
@@ -1,4 +1,4 @@
-description: Error response when trying to see favourited worlds of another user without sufficient admin permissions.
+description: Error response when trying to see favorited worlds of another user without sufficient admin permissions.
 content:
   application/json:
     examples:

--- a/openapi/components/schemas/CalendarEventRecurrenceEndType.yaml
+++ b/openapi/components/schemas/CalendarEventRecurrenceEndType.yaml
@@ -1,4 +1,4 @@
-title: CalendarEventRecurrenceEndTyoe
+title: CalendarEventRecurrenceEndType
 type: string
 description: How a recurring event stops being scheduled
 enum:

--- a/openapi/components/tags.yaml
+++ b/openapi/components/tags.yaml
@@ -34,6 +34,9 @@
 - name: jams
   description:
     $ref: ./paths/jams.yaml#/info/description
+- name: miscellaneous
+  description:
+    $ref: ./paths/miscellaneous.yaml#/info/description
 - name: notifications
   description:
     $ref: ./paths/notifications.yaml#/info/description
@@ -52,6 +55,3 @@
 - name: worlds
   description:
     $ref: ./paths/worlds.yaml#/info/description
-- name: miscellaneous
-  description:
-    $ref: ./paths/miscellaneous.yaml#/info/description

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
 packages:
   - .
+allowBuilds:
+  core-js: true
+  esbuild: true
+  protobufjs: true
+  unrs-resolver: true

--- a/spectral/index.ts
+++ b/spectral/index.ts
@@ -16,6 +16,7 @@ import { parseArgs } from "node:util";
 import { error, notice, summary, warning } from "@actions/core";
 import { Document, Ruleset, Spectral } from "@stoplight/spectral-core";
 import Parsers from "@stoplight/spectral-parsers";
+import Bun from "bun";
 
 import { defaultRuleset } from "./ruleset";
 

--- a/spectral/lib/typos.ts
+++ b/spectral/lib/typos.ts
@@ -11,7 +11,26 @@ const words = [
 	"favorited",
 	"vrchatplus",
 	"unban",
-	"unmute"
+	"unmute",
+	"spritesheet",
+	"despawns",
+	"urlencode",
+	"unmoderates",
+	"standalonewindows",
+	"unknownplatform",
+	"booping",
+	"unequip",
+	"playermoderation",
+	"unmoderate",
+	"interactable",
+	"bitmask",
+	"unbans",
+	"unequips",
+	"equippable",
+	"unmoderated",
+	"unmoderating",
+	"webform",
+	"recents"
 ];
 
 const suggestWords = [


### PR DESCRIPTION
* fix a bunch of typo warnings in the various spec documents
* Add Bun type import to fix type error
* Pnpm v10.26.0 disables npm package postinstall scripts by default, this adds the packages to `allowBuilds` in `pnpm-workspace.yaml` to allow their `postinstall` scripts to run
  * see https://pnpm.io/supply-chain-security and https://pnpm.io/settings#allowbuilds