### PR TITLE
Output release variable in release_dispatch workflow

### DIFF
--- a/.github/workflows/release_dispatch.yaml
+++ b/.github/workflows/release_dispatch.yaml
@@ -41,6 +41,8 @@ jobs:
             )
           }')
 
+          echo ${release}
+
           jq -n --argjson payload "$release" '{ event_type: "release", client_payload: $payload }' \
           | gh api repos/{owner}/${{ matrix.repository }}/dispatches -X POST -i --input -
         env:


### PR DESCRIPTION
Add echo command to output the release variable before dispatching, to make worflow dispatches in the language projects (e.g. c# or rust) simpler, by not requiring to run the command ourselves.