### PR TITLE
Add missing CurrentUser provider fields for Apple and Twitch

### DIFF
--- a/openapi/components/schemas/CurrentUser.yaml
+++ b/openapi/components/schemas/CurrentUser.yaml
@@ -30,6 +30,10 @@ properties:
     $ref: ./AgeVerified.yaml
   allowAvatarCopying:
     type: boolean
+  appleDetails:
+    type: object
+  appleId:
+    type: string
   authToken:
     type: string
     description: The auth token for NEWLY REGISTERED ACCOUNTS ONLY (/auth/register)
@@ -201,6 +205,10 @@ properties:
     type: array
     items:
       $ref: ./Tag.yaml
+  twitchDetails:
+    type: object
+  twitchId:
+    type: string
   twoFactorAuthEnabled:
     type: boolean
   twoFactorAuthEnabledDate:


### PR DESCRIPTION
## Summary

This change updates the CurrentUser OpenAPI schema to include the missing provider-related fields reported by newer VRChat API responses:

- `appleDetails`
- `appleId`
- `twitchDetails`
- `twitchId`

## Why

Some current user responses include these fields, and the previous schema did not define them. That caused deserialization and validation issues for clients generated from this spec.

## What changed

- Added the missing properties to [openapi/components/schemas/CurrentUser.yaml](openapi/components/schemas/CurrentUser.yaml)

## Validation

- Verified the patch branch locally
- Ran the repository validation command successfully after installing Bun